### PR TITLE
improvement: add fixup commits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "magit",
-	"version": "0.0.7",
+	"version": "0.0.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -17,7 +17,7 @@ const commitMenu = {
     { label: 'a', description: 'Amend', action: (menuState: MenuState) => commit(menuState, ['--amend']) },
     { label: 'e', description: 'Extend', action: (menuState: MenuState) => commit(menuState, ['--amend', '--no-edit']) },
     { label: 'w', description: 'Reword', action: (menuState: MenuState) => commit(menuState, ['--amend', '--only']) },
-    // { label: "f", description: "Fixup", action: (menuState: MenuState) => commit(menuState.repository, ['--fixup']) },
+    { label: 'f', description: 'Fixup', action: (menuState: MenuState) => fixup(menuState) },
   ]
 };
 
@@ -36,6 +36,18 @@ export async function commit({ repository, switches }: MenuState, commitArgs: st
   const args = ['commit', ...MenuUtil.switchesToArgs(switches), ...commitArgs];
 
   return runCommitLikeCommand(repository, args);
+}
+
+export async function fixup({ repository, switches }: MenuState) {
+  const sha = await MagitUtils.chooseCommit(repository, 'Fixup commit');
+
+  if (sha) {
+    const args = ['commit', ...MenuUtil.switchesToArgs(switches), '--fixup', sha];
+
+    return await gitRun(repository, args);
+  } else {
+    throw new Error('No commit chosen to fixup');
+  }
 }
 
 export async function runCommitLikeCommand(repository: MagitRepository, args: string[]) {

--- a/src/utils/magitUtils.ts
+++ b/src/utils/magitUtils.ts
@@ -6,6 +6,7 @@ import { DocumentView } from '../views/general/documentView';
 import FilePathUtils from './filePathUtils';
 import { RefType, Repository } from '../typings/git';
 import { QuickItem, QuickMenuUtil } from '../menu/quickMenu';
+import GitTextUtils from '../utils/gitTextUtils';
 
 export default class MagitUtils {
 
@@ -93,6 +94,18 @@ export default class MagitUtils {
       .sort((refA, refB) => refA.type - refB.type).map(r => r.name!));
 
     return window.showQuickPick(refs, { placeHolder: prompt });
+  }
+
+  public static async chooseCommit(repository: MagitRepository, prompt: string) {
+    return repository.log({ maxEntries: 100 })
+      .then(log => log.map(commit => {
+        const shortHash = GitTextUtils.shortHash(commit.hash)
+        return {
+          label: shortHash,
+          description: commit.message.concat(' ').concat(commit.hash),
+          meta: shortHash
+        };
+      })).then(menu => QuickMenuUtil.showMenuWithFreeform(menu));
   }
 
   public static async chooseTag(repository: MagitRepository, prompt: string) {


### PR DESCRIPTION
Added the ability to create a fixup commit, similar to the way magit allows. However, I much prefer the type-ahead/quick pick style in VSCode, so I think that is the way to go. Open to any/all feedback.

![fixup](https://user-images.githubusercontent.com/5722339/76693687-d9b96480-663f-11ea-8a14-edc76efe34f7.gif)

Resolves: https://github.com/kahole/vscode-magit/issues/9
