### PR TITLE
Allow commiting without having code in PATH on win32 and linux

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -81,10 +81,8 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
     // Find the code binary on different platforms.
     if (process.platform === 'darwin') {
       codePath = execPath.split(/(?<=\.app)/)[0] + '/Contents/Resources/app/bin/' + codePath;
-    } else if (process.platform === 'win32') {
+    } else if (process.platform === 'win32' || process.platform === 'linux') {
       codePath = path.join(path.dirname(execPath), 'bin', codePath);
-    } else if (process.platform === 'linux') {
-      codePath = execPath;
     }
 
     const env = { [editor ?? 'GIT_EDITOR']: `"${codePath}" --wait` };

--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -1,4 +1,5 @@
 import { window, ViewColumn, TextEditor, commands } from 'vscode';
+import * as vscode from 'vscode';
 import * as Constants from '../common/constants';
 import { execPath } from 'process';
 import { MagitRepository } from '../models/magitRepository';
@@ -67,12 +68,19 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
       stagedEditorTask = showDiffSection(repository, Section.Staged, true);
     }
 
+    // Check if we are currently running a Code Insiders build.
+    // This checking code is lifted from vscode-python extension by Microsoft.
+    let isInsiders = vscode.env.appName.indexOf('Insider') > 0;
+
     let codePath = 'code';
+    if (isInsiders) {
+      codePath = 'code-insiders';
+    }
 
     // Only for mac
     // can only use "code" if it is in path. Vscode command: "Shell Command: Install code in path"
     if (process.platform === 'darwin') {
-      codePath = execPath.split(/(?<=\.app)/)[0] + '/Contents/Resources/app/bin/code';
+      codePath = execPath.split(/(?<=\.app)/)[0] + '/Contents/Resources/app/bin/' + codePath;
     }
 
     const env = { [editor ?? 'GIT_EDITOR']: `"${codePath}" --wait` };

--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -8,6 +8,7 @@ import { MenuUtil, MenuState } from '../menu/menu';
 import MagitUtils from '../utils/magitUtils';
 import { showDiffSection } from './diffingCommands';
 import { Section } from '../views/general/sectionHeader';
+import * as path from 'path';
 
 const commitMenu = {
   title: 'Committing',
@@ -77,10 +78,13 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
       codePath = 'code-insiders';
     }
 
-    // Only for mac
-    // can only use "code" if it is in path. Vscode command: "Shell Command: Install code in path"
+    // Find the code binary on different platforms.
     if (process.platform === 'darwin') {
       codePath = execPath.split(/(?<=\.app)/)[0] + '/Contents/Resources/app/bin/' + codePath;
+    } else if (process.platform === 'win32') {
+      codePath = path.join(path.dirname(execPath), 'bin', codePath);
+    } else if (process.platform === 'linux') {
+      codePath = execPath;
     }
 
     const env = { [editor ?? 'GIT_EDITOR']: `"${codePath}" --wait` };


### PR DESCRIPTION
This PR fixes the commit flow to work in more situation:

- On windows and linux, it will look for the code wrapper script in the correct places
- When code-insiders is used, it will use the correct script name "code-insiders"

This should additionally make it work seamlessly when using vscode in Remote SSH mode, where the `code`/`code-insiders` script is unlikely to be in the PATH, but is untested until I can figure out how to load an extension from outside the marketplace on the remote server.