### PR TITLE
Initial forge support.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,127 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@octokit/auth-token": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+			"requires": {
+				"@octokit/types": "^5.0.0"
+			}
+		},
+		"@octokit/core": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+			"integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+			"requires": {
+				"@octokit/auth-token": "^2.4.0",
+				"@octokit/graphql": "^4.3.1",
+				"@octokit/request": "^5.4.0",
+				"@octokit/types": "^5.0.0",
+				"before-after-hook": "^2.1.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/endpoint": {
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+			"integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
+			"requires": {
+				"@octokit/types": "^5.0.0",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+				}
+			}
+		},
+		"@octokit/graphql": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+			"integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
+			"requires": {
+				"@octokit/request": "^5.3.0",
+				"@octokit/types": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/plugin-paginate-rest": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz",
+			"integrity": "sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==",
+			"requires": {
+				"@octokit/types": "^5.5.0"
+			}
+		},
+		"@octokit/plugin-request-log": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+		},
+		"@octokit/plugin-rest-endpoint-methods": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.0.tgz",
+			"integrity": "sha512-1/qn1q1C1hGz6W/iEDm9DoyNoG/xdFDt78E3eZ5hHeUfJTLJgyAMdj9chL/cNBHjcjd+FH5aO1x0VCqR2RE0mw==",
+			"requires": {
+				"@octokit/types": "^5.5.0",
+				"deprecation": "^2.3.1"
+			}
+		},
+		"@octokit/request": {
+			"version": "5.4.9",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+			"integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+			"requires": {
+				"@octokit/endpoint": "^6.0.1",
+				"@octokit/request-error": "^2.0.0",
+				"@octokit/types": "^5.0.0",
+				"deprecation": "^2.0.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"once": "^1.4.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+				}
+			}
+		},
+		"@octokit/request-error": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+			"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+			"requires": {
+				"@octokit/types": "^5.0.1",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			}
+		},
+		"@octokit/rest": {
+			"version": "18.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.6.tgz",
+			"integrity": "sha512-ES4lZBKPJMX/yUoQjAZiyFjei9pJ4lTTfb9k7OtYoUzKPDLl/M8jiHqt6qeSauyU4eZGLw0sgP1WiQl9FYeM5w==",
+			"requires": {
+				"@octokit/core": "^3.0.0",
+				"@octokit/plugin-paginate-rest": "^2.2.0",
+				"@octokit/plugin-request-log": "^1.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "4.2.0"
+			}
+		},
+		"@octokit/types": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+			"integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+			"requires": {
+				"@types/node": ">= 8"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -67,13 +188,12 @@
 		"@types/node": {
 			"version": "12.12.55",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.55.tgz",
-			"integrity": "sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw==",
-			"dev": true
+			"integrity": "sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw=="
 		},
 		"@types/vscode": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-			"integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
+			"integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -603,6 +723,11 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
 			"dev": true
+		},
+		"before-after-hook": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -1253,6 +1378,11 @@
 					}
 				}
 			}
+		},
+		"deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
 		},
 		"des.js": {
 			"version": "1.0.1",
@@ -3264,6 +3394,11 @@
 				}
 			}
 		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
 		"node-libs-browser": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -3414,7 +3549,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -4660,6 +4794,11 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"universal-user-agent": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+			"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -5409,8 +5548,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "version": "0.4.5",
   "engines": {
-    "vscode": "^1.42.1"
+    "vscode": "^1.48.0"
   },
   "icon": "images/edamagit_logo.png",
   "galleryBanner": {
@@ -659,7 +659,7 @@
   "devDependencies": {
     "@types/glob": "^7.1.3",
     "@types/mocha": "^7.0.1",
-    "@types/vscode": "^1.42.1",
+    "@types/vscode": "^1.48.0",
     "@types/node": "^12.12.55",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
@@ -675,6 +675,7 @@
   },
   "dependencies": {
     "date-fns": "^2.16.1",
-    "jsonc-parser": "^2.3.0"
+    "jsonc-parser": "^2.3.0",
+    "@octokit/rest": "18.0.6"
   }
 }

--- a/src/commands/branchingCommands.ts
+++ b/src/commands/branchingCommands.ts
@@ -1,33 +1,42 @@
 import { window, workspace } from 'vscode';
 import { views } from '../extension';
 import { MenuState, MenuUtil } from '../menu/menu';
+import { PickMenuUtil } from '../menu/pickMenu';
 import { MagitRepository } from '../models/magitRepository';
 import { GitErrorCodes, Ref, RefType } from '../typings/git';
 import { gitRun } from '../utils/gitRawRunner';
 import MagitUtils from '../utils/magitUtils';
 import ShowRefsView from '../views/showRefsView';
 
-const branchingMenu = {
-  title: 'Branching',
-  commands: [
-    { label: 'b', description: 'Checkout', action: checkout },
-    { label: 'l', description: 'Checkout local branch', action: checkoutLocal },
-    { label: 'c', description: 'Checkout new branch', action: checkoutNewBranch },
-    // { label: "w", description: "Checkout new worktree", action: checkout },
-    // { label: "y", description: "Checkout pull-request", action: checkout },
-    // { label: "s", description: "Create new spin-off", action: createNewSpinoff },
-    { label: 'n', description: 'Create new branch', action: createNewBranch },
-    // { label: "W", description: "Create new worktree", action: checkout },
-    // { label: "Y", description: "Create from pull-request", action: checkout },
-    // { label: 'C', description: 'Configure', action: configureBranch },
-    { label: 'm', description: 'Rename', action: renameBranch },
-    { label: 'x', description: 'Reset', action: resetBranch },
-    { label: 'k', description: 'Delete', action: deleteBranch },
-  ]
-};
+const branchingCommands = [
+  { label: 'b', description: 'Checkout', action: checkout },
+  { label: 'l', description: 'Checkout local branch', action: checkoutLocal },
+  { label: 'c', description: 'Checkout new branch', action: checkoutNewBranch },
+  // { label: "w", description: "Checkout new worktree", action: checkout },
+  // { label: "y", description: "Checkout pull-request", action: checkout },
+  // { label: "s", description: "Create new spin-off", action: createNewSpinoff },
+  { label: 'n', description: 'Create new branch', action: createNewBranch },
+  // { label: "W", description: "Create new worktree", action: checkout },
+  // { label: "Y", description: "Create from pull-request", action: checkout },
+  // { label: 'C', description: 'Configure', action: configureBranch },
+  { label: 'm', description: 'Rename', action: renameBranch },
+  { label: 'x', description: 'Reset', action: resetBranch },
+  { label: 'k', description: 'Delete', action: deleteBranch },
+];
+
+const forgeBranchingCommands = [
+  { label: 'y', description: 'Checkout pull request', action: checkoutPullRequest },
+];
 
 export async function branching(repository: MagitRepository) {
-  return MenuUtil.showMenu(branchingMenu, { repository });
+  let menu = {
+    title: 'Branching',
+    commands: Array.from(branchingCommands)
+  };
+  if (repository.forgeState !== null) {
+    menu.commands.push(...forgeBranchingCommands);
+  }
+  return MenuUtil.showMenu(menu, { repository });
 }
 
 export async function showRefs(repository: MagitRepository) {
@@ -51,6 +60,24 @@ async function checkoutLocal(menuState: MenuState) {
 
 async function checkoutNewBranch(menuState: MenuState) {
   return _createBranch(menuState, true);
+}
+
+async function checkoutPullRequest(menuState: MenuState) {
+  const state = menuState.repository;
+  const prs = state.forgeState?.pullRequests;
+  if (state.forgeState === undefined || !prs?.length) {
+    // TODO: User feedback when there are no PRs to checkout.
+    return;
+  }
+  const prItems = prs.map((v, idx) => ({
+    label: v.id.toString(),
+    description: v.name,
+    meta: idx
+  }));
+  const prIdx = await PickMenuUtil.showMenu(prItems, 'Checkout pull request');
+  const pr = prs[prIdx];
+  await gitRun(state.gitRepository, ['fetch', state.forgeState?.forgeRemote, `${pr.remoteRef}:pr-${pr.id}`]);
+  return gitRun(state.gitRepository, ['checkout', `pr-${pr.id}`]);
 }
 
 async function createNewBranch(menuState: MenuState) {

--- a/src/commands/statusCommands.ts
+++ b/src/commands/statusCommands.ts
@@ -17,6 +17,8 @@ import { MagitMergingState } from '../models/magitMergingState';
 import { MagitRevertingState } from '../models/magitRevertingState';
 import { Stash } from '../models/stash';
 import { MagitRepository } from '../models/magitRepository';
+import { findForge } from '../utils/forgeUtils';
+import { URL } from 'url';
 
 export async function magitRefresh() { }
 
@@ -172,6 +174,13 @@ export async function internalMagitStatus(repository: Repository): Promise<Magit
       remoteBranch.name !== remote.name + '/HEAD') // filter out uninteresting remote/HEAD element
   }));
 
+  // Check remotes, in order: upstream, origin.
+  let forgeRemote = remotes.find(v => v.name === 'upstream');
+  let forge = null;
+  if (forgeRemote?.fetchUrl !== undefined) {
+    forge = await findForge(new URL(forgeRemote?.fetchUrl));
+  }
+
   return {
     uri: repository.rootUri,
     HEAD,
@@ -190,7 +199,9 @@ export async function internalMagitStatus(repository: Repository): Promise<Magit
     tags: repository.state.refs.filter(ref => ref.type === RefType.Tag),
     refs: repository.state.refs,
     submodules: repository.state.submodules,
-    gitRepository: repository
+    gitRepository: repository,
+
+    pullRequests: await forge?.getPullRequests() || []
   };
 }
 

--- a/src/commands/statusCommands.ts
+++ b/src/commands/statusCommands.ts
@@ -201,7 +201,10 @@ export async function internalMagitStatus(repository: Repository): Promise<Magit
     submodules: repository.state.submodules,
     gitRepository: repository,
 
-    pullRequests: await forge?.getPullRequests() || []
+    forgeState: forgeRemote ? {
+      forgeRemote: forgeRemote.name,
+      pullRequests: await forge?.getPullRequests() || []
+    } : undefined,
   };
 }
 

--- a/src/models/magitRepository.ts
+++ b/src/models/magitRepository.ts
@@ -31,5 +31,10 @@ export interface MagitRepository {
   readonly submodules: Submodule[];
   readonly gitRepository: Repository;
 
+  readonly forgeState?: ForgeState;
+}
+
+export interface ForgeState {
+  readonly forgeRemote: string;
   readonly pullRequests: PullRequest[];
 }

--- a/src/models/magitRepository.ts
+++ b/src/models/magitRepository.ts
@@ -8,6 +8,7 @@ import { MagitRemote } from './magitRemote';
 import { MagitCherryPickingState } from './magitCherryPickingState';
 import { MagitRevertingState } from './magitRevertingState';
 import { Stash } from './stash';
+import { PullRequest } from './pullRequest';
 import { Uri } from 'vscode';
 
 export interface MagitRepository {
@@ -29,4 +30,6 @@ export interface MagitRepository {
   readonly refs: Ref[];
   readonly submodules: Submodule[];
   readonly gitRepository: Repository;
+
+  readonly pullRequests: PullRequest[];
 }

--- a/src/models/pullRequest.ts
+++ b/src/models/pullRequest.ts
@@ -1,0 +1,9 @@
+export interface PullRequest {
+  id: number;
+  name: string;
+}
+
+export interface Label {
+  name: string;
+  color: string;
+}

--- a/src/models/pullRequest.ts
+++ b/src/models/pullRequest.ts
@@ -1,6 +1,8 @@
 export interface PullRequest {
   id: number;
   name: string;
+  labels: Label[];
+  remoteRef: string;
 }
 
 export interface Label {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -36,7 +36,6 @@ suite('Extension Test Suite', () => {
     //       parents: []
     //     }
     //   },
-    //   pullRequests: [],
     // };
 
     // const statusView = new MagitStatusView(vscode.Uri.parse(''), magitState);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -35,7 +35,8 @@ suite('Extension Test Suite', () => {
     //       message: 'ok',
     //       parents: []
     //     }
-    //   }
+    //   },
+    //   pullRequests: [],
     // };
 
     // const statusView = new MagitStatusView(vscode.Uri.parse(''), magitState);

--- a/src/utils/forgeUtils.ts
+++ b/src/utils/forgeUtils.ts
@@ -1,0 +1,55 @@
+import { PullRequest } from '../models/pullRequest';
+import { Octokit } from '@octokit/rest';
+import { URL } from 'url';
+import * as vscode from 'vscode';
+
+const GITHUB_AUTH_PROVIDER_ID = 'github';
+const SCOPES = ['repos'];
+
+export interface Forge {
+  getPullRequests(): Promise<PullRequest[]>;
+}
+
+class Github implements Forge {
+  constructor(
+    public owner: string,
+    public repo: string,
+    public octokit: Octokit) {}
+
+  async getPullRequests(): Promise<PullRequest[]> {
+    try {
+      let prs = await this.octokit.pulls.list({
+        owner: this.owner,
+        repo: this.repo,
+      });
+
+      return prs.data.map(v => {
+        return {
+          id: v.number,
+          name: v.title
+        };
+      });
+    } catch (err) {
+      // Catch errors like 404, return an empty list instead.
+      console.error(err);
+      return [];
+    }
+  }
+}
+
+export async function findForge(url: URL): Promise<Forge | null> {
+  if (url.hostname === 'github.com') {
+    const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: false });
+
+    if (session) {
+      const octokit = new Octokit({
+        userAgent: 'edamagit-forge',
+        auth: session.accessToken
+      });
+      const owner = url.pathname.split('/').filter(Boolean)[0];
+      const repo = url.pathname.split('/').filter(Boolean)[1];
+      return new Github(owner, repo, octokit);
+    }
+  }
+  return null;
+}

--- a/src/utils/forgeUtils.ts
+++ b/src/utils/forgeUtils.ts
@@ -23,12 +23,15 @@ class Github implements Forge {
         repo: this.repo,
       });
 
-      return prs.data.map(v => {
-        return {
-          id: v.number,
-          name: v.title
-        };
-      });
+      return prs.data.map(v => ({
+        id: v.number,
+        name: v.title,
+        labels: v.labels.map(v => ({
+          name: v.name,
+          color: v.color,
+        })),
+        remoteRef: `pull/${v.number}/head`,
+      }));
     } catch (err) {
       // Catch errors like 404, return an empty list instead.
       console.error(err);

--- a/src/views/forge/pullRequestView.ts
+++ b/src/views/forge/pullRequestView.ts
@@ -7,7 +7,7 @@ import { TextView } from '../general/textView';
 export class PullRequestSectionView extends View {
   isFoldable = true;
 
-  get id() { return Section.Stashes.toString(); }
+  get id() { return Section.PullRequests.toString(); }
 
   constructor(prs: PullRequest[]) {
     super();

--- a/src/views/forge/pullRequestView.ts
+++ b/src/views/forge/pullRequestView.ts
@@ -1,0 +1,34 @@
+import { View } from '../general/view';
+import { Section, SectionHeaderView } from '../general/sectionHeader';
+import { LineBreakView } from '../general/lineBreakView';
+import { PullRequest } from '../../models/pullRequest';
+import { TextView } from '../general/textView';
+
+export class PullRequestSectionView extends View {
+  isFoldable = true;
+
+  get id() { return Section.Stashes.toString(); }
+
+  constructor(prs: PullRequest[]) {
+    super();
+    this.subViews = [
+      new SectionHeaderView(Section.PullRequests, prs.length),
+      ...prs.map(pr => new PullRequestItemView(pr)),
+      new LineBreakView()
+    ];
+  }
+}
+
+export class PullRequestItemView extends TextView {
+  public get section() {
+    return PullRequestItemView.getSection(this.pr);
+  }
+
+  private static getSection(pr: PullRequest) {
+    return `#${pr.id}`;
+  }
+
+  constructor(public pr: PullRequest) {
+    super(`${PullRequestItemView.getSection(pr)} ${pr.name}`);
+  }
+}

--- a/src/views/general/sectionHeader.ts
+++ b/src/views/general/sectionHeader.ts
@@ -15,7 +15,8 @@ export enum Section {
   HEAD = 'HEAD',
   Branches = 'Branches',
   Remote = 'Remote',
-  Tags = 'Tags'
+  Tags = 'Tags',
+  PullRequests = 'Pull Requests',
 }
 
 export class SectionHeaderView extends TextView {

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -91,8 +91,8 @@ export default class MagitStatusView extends DocumentView {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsBehind, refs));
     }
 
-    if (magitState.pullRequests?.length) {
-      this.addSubview(new PullRequestSectionView(magitState.pullRequests));
+    if (magitState.forgeState?.pullRequests?.length) {
+      this.addSubview(new PullRequestSectionView(magitState.forgeState?.pullRequests));
     }
   }
 

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -16,6 +16,7 @@ import { CherryPickingSectionView } from './cherryPicking/cherryPickingSectionVi
 import { RevertingSectionView } from './reverting/revertingSectionView';
 import { MagitBranch } from '../models/magitBranch';
 import { getLatestGitError } from '../commands/commandPrimer';
+import { PullRequestSectionView } from './forge/pullRequestView';
 
 export default class MagitStatusView extends DocumentView {
 
@@ -88,6 +89,10 @@ export default class MagitStatusView extends DocumentView {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsBehind, refs));
     } else if (magitState.HEAD?.pushRemote?.commitsBehind?.length) {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsBehind, refs));
+    }
+
+    if (magitState.pullRequests?.length) {
+      this.addSubview(new PullRequestSectionView(magitState.pullRequests));
     }
   }
 

--- a/syntaxes/magit.tmGrammar.json
+++ b/syntaxes/magit.tmGrammar.json
@@ -38,7 +38,7 @@
       ]
     },
     "sectionHeader": {
-      "match": "^(Untracked files|((Unstaged|Staged) changes)|Stashes|Recent commits|Unmerged into|Unpushed to|Unpulled from|HEAD|Branches|Remote|Tags|GitError!|(Merging .*(?= \\())|(Rebasing .* onto .*$)|Cherry Picking|Reverting|Stash@{\\d+}|(Commits in .*$))",
+      "match": "^(Untracked files|((Unstaged|Staged) changes)|Stashes|Recent commits|Unmerged into|Unpushed to|Unpulled from|HEAD|Branches|Remote|Tags|Pull Requests|GitError!|(Merging .*(?= \\())|(Rebasing .* onto .*$)|Cherry Picking|Reverting|Stash@{\\d+}|(Commits in .*$))",
       "name": "strong keyword.operator.new.section.header.magit"
     },
     "highlight": {
@@ -65,7 +65,7 @@
       "match": "^(modified|new file|deleted|renamed|copied|unmerged)   .*$",
       "name": "strong"
     },
-    "diff": { 
+    "diff": {
       "begin": "(?=^@@)",
       "end": "(?=^(modified|new file|deleted|renamed|copied|unmerged))|(?=$^)",
       "patterns": [


### PR DESCRIPTION
Starting work towards closing #62 

Here is a progress list for feature parity with magit-forge.

A few implementation notes:
- This currently implemented target is Github (on github.com, no enterprise support), though I do try to make things generic enough such that adding another backend shouldn't be too difficult.
- We use the VSCode Authentication Provider system, which makes for a fairly painless onboarding. Plus, I believe it will allow edamagit to Just Work:tm: in Github Codespaces.
- To avoid spamming the server with requests and slowing the UI too much, Magit-Forge stores information in a local sqlite database. This also allows it to work offline in read-only mode. This PR doesn't currently do this.

Here's a bit of a roadmap for this PR:

- Magit Status
  - [ ] Show issues
  - [x] Show pull requests
    - TODO: Show labels.
- Topic List
  - [ ] Show all topics within a list (PR or Issues)
    - Note: Need to think about pagination here. Getting all the issues will probably be a bad idea on big repos with thousands of opened issues.
- Topic
  - [ ] Implement topic information view (https://magit.vc/manual/forge.html#Visiting-Topics)
  - [ ] Implement issue creation
  - [ ] Implement PR creation
  - [ ] Implement topic manipulation (e.g. changing topic state, labels, etc...)
  - [ ] Implement post creation and edition. (comments in an issue, PR).
- Pull request checkout commands
  - [x] forge-checkout-pullreq (`b y`)
  - [ ] forge-branch-pullreq (`b Y`)
  - [ ] forge-checkout-worktree (`% y`)
- [ ] Fork command

Here's a screenshot:
![image](https://user-images.githubusercontent.com/1069318/93672256-c3d2a380-faa9-11ea-88fd-9551411ac2a4.png)

