### PR TITLE
commit: add signoff switch

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -27,7 +27,8 @@ export async function magitCommit(repository: MagitRepository) {
 
   const switches = [
     { key: '-a', name: '--all', description: 'Stage all modified and deleted files' },
-    { key: '-e', name: '--allow-empty', description: 'Allow empty commit' }
+    { key: '-e', name: '--allow-empty', description: 'Allow empty commit' },
+    { key: '-s', name: '--signoff', description: 'Add Signed-off-by line' },
   ];
 
   return MenuUtil.showMenu(commitMenu, { repository, switches });


### PR DESCRIPTION
This is a small PR that adds the `-s` switch to signoff commits, just like in the original magit.