### PR TITLE
Fix commit on remote windows vscode

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -157,6 +157,7 @@ function findCodePath(): string {
   let isInsiders = vscode.env.appName.includes('Insider');
   let isCodium = vscode.env.appName.includes('Codium');
   let isDarwin = process.platform === 'darwin';
+  let isWindows = process.platform === 'win32';
 
   let codePath = 'code';
   if (isCodium && !isDarwin) {
@@ -165,6 +166,10 @@ function findCodePath(): string {
   if (isInsiders && !isDarwin) {
     // On Mac the binary for the Insiders build is still called `code`
     codePath += '-insiders';
+  }
+  if (isWindows) {
+    // On window remote server, 'code' alias doesn't exist
+    codePath += '.cmd';
   }
 
   // Find the code binary on different platforms.


### PR DESCRIPTION
This fixes the issue where committing fails to lunch editor in vscode using VS Code remote windows server due to missing file.

Files on Windows machine:
- execPath/bin/code
- execPath/bin/code.cmd

Files on Windows remote server:
- execPath/bin/code.cmd

This commit will make sure it use `code.cmd` on Windows which exists on both Windows local and server instance of vscode.