### PR TITLE
Add setting to hide status sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,6 +400,11 @@
           "default": false,
           "description": "Enable Forge functionality (show pull requests, issues, etc from e.g. Github)"
         },
+        "magit.hide-status-sections": {
+          "type": "array",
+          "default": [],
+          "description": "Array of section names to be hidden in status view. The section names that may be hidden are: 'issues', 'pull requests', 'recent commits', 'staged', 'stashes', 'unmerged', 'unpulled', 'unpushed', 'unstaged', 'untracked'."
+        },
         "magit.quick-switch-enabled": {
           "type": "boolean",
           "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export const processLog: MagitProcessLogEntry[] = [];
 
 export let gitApi: API;
 export let logPath: string;
-export let magitConfig: { displayBufferSameColumn?: boolean, forgeEnabled?: boolean, quickSwitchEnabled?: boolean };
+export let magitConfig: { displayBufferSameColumn?: boolean, forgeEnabled?: boolean, hiddenStatusSections: Set<string>, quickSwitchEnabled?: boolean };
 
 function loadConfig() {
   let workspaceConfig = workspace.getConfiguration('magit');
@@ -56,8 +56,17 @@ function loadConfig() {
   magitConfig = {
     displayBufferSameColumn: workspaceConfig.get('display-buffer-function') === 'same-column',
     forgeEnabled: workspaceConfig.get('forge-enabled'),
+    hiddenStatusSections: readHiddenStatusSections(workspaceConfig.get('hide-status-sections')),
     quickSwitchEnabled: workspaceConfig.get('quick-switch-enabled')
   };
+}
+
+function readHiddenStatusSections(configEntry: any): Set<string> {
+  if (Array.isArray(configEntry)) {
+    return new Set(configEntry);
+  } else {
+    return new Set();
+  }
 }
 
 export function activate(context: ExtensionContext) {

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -1,4 +1,5 @@
 import * as Constants from '../common/constants';
+import { magitConfig } from '../extension';
 import { ChangeSectionView } from './changes/changesSectionView';
 import { Section } from './general/sectionHeader';
 import { DocumentView } from './general/documentView';
@@ -58,45 +59,44 @@ export default class MagitStatusView extends DocumentView {
       this.addSubview(new RevertingSectionView(magitState.revertingState, magitState.log));
     }
 
-    if (magitState.untrackedFiles.length) {
+    if (magitState.untrackedFiles.length && !magitConfig.hiddenStatusSections.has('untracked')) {
       this.addSubview(new ChangeSectionView(Section.Untracked, magitState.untrackedFiles));
     }
 
-    if (magitState.workingTreeChanges.length || magitState.mergeChanges.length) {
+    if ((magitState.workingTreeChanges.length || magitState.mergeChanges.length) && !magitConfig.hiddenStatusSections.has('unstaged')) {
       this.addSubview(new ChangeSectionView(Section.Unstaged, [...magitState.mergeChanges, ...magitState.workingTreeChanges]));
     }
 
-    if (magitState.indexChanges.length) {
+    if (magitState.indexChanges.length && !magitConfig.hiddenStatusSections.has('staged')) {
       this.addSubview(new ChangeSectionView(Section.Staged, magitState.indexChanges));
     }
 
-    if (magitState.stashes?.length) {
+    if (magitState.stashes?.length && !magitConfig.hiddenStatusSections.has('stashes')) {
       this.addSubview(new StashSectionView(magitState.stashes));
     }
 
     const refs = magitState.remotes.reduce((prev, remote) => remote.branches.concat(prev), magitState.branches.concat(magitState.tags));
 
-    if (magitState.HEAD?.upstreamRemote?.commitsAhead?.length) {
+    if (magitState.HEAD?.upstreamRemote?.commitsAhead?.length && !magitConfig.hiddenStatusSections.has('unmerged')) {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnmergedInto, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsAhead, refs));
-    } else if (magitState.HEAD?.pushRemote?.commitsAhead?.length) {
+    } else if (magitState.HEAD?.pushRemote?.commitsAhead?.length && !magitConfig.hiddenStatusSections.has('unpushed')) {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnpushedTo, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsAhead, refs));
     }
-
-    if (magitState.log.length > 0 && !magitState.HEAD?.upstreamRemote?.commitsAhead?.length) {
+    if (magitState.log.length > 0 && !magitState.HEAD?.upstreamRemote?.commitsAhead?.length && !magitConfig.hiddenStatusSections.has('recent commits')) {
       this.addSubview(new CommitSectionView(Section.RecentCommits, magitState.log.slice(0, 10), refs));
     }
 
-    if (magitState.HEAD?.upstreamRemote?.commitsBehind?.length) {
+    if (magitState.HEAD?.upstreamRemote?.commitsBehind?.length && !magitConfig.hiddenStatusSections.has('unpulled')) {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsBehind, refs));
     } else if (magitState.HEAD?.pushRemote?.commitsBehind?.length) {
       this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsBehind, refs));
     }
 
-    if (magitState.forgeState?.pullRequests?.length) {
+    if (magitState.forgeState?.pullRequests?.length && !magitConfig.hiddenStatusSections.has('pull requests')) {
       this.addSubview(new PullRequestSectionView(magitState.forgeState?.pullRequests));
     }
 
-    if (magitState.forgeState?.issues?.length) {
+    if (magitState.forgeState?.issues?.length && !magitConfig.hiddenStatusSections.has('issues')) {
       this.addSubview(new IssueSectionView(magitState.forgeState?.issues));
     }
   }


### PR DESCRIPTION
Fixes #120

This PR adds a new setting, allowing the status view sections to be hidden:

<table><tr><td><img width=600px src="https://user-images.githubusercontent.com/52205/113932893-f16f0800-97c1-11eb-87b1-453652a5a168.png" alt="image" /></td></tr></table>

(I was uncomfortable hard-coding that list of section names; see comment below.)

I haven't edited the changelog.

### How tested

- I've compiled and installed the extension and verified non-systematically that changing array entries causes the sections to drop out / re-appear as expected.
- I've confirmed that intellisense in the `settings.json` editor instructs me that it should be an array and highlights any type error.
- I've confirmed that entering a non-array value is ignored silently
- I have *not* tested anything forge-related.


--------------------------

<table><tr><td><img width=600px src="https://user-images.githubusercontent.com/52205/113933555-bb7e5380-97c2-11eb-83b1-56ea7cbf919d.png" alt="image" /></td></tr></table>

<table><tr><td><img width=600px src="https://user-images.githubusercontent.com/52205/113933621-cf29ba00-97c2-11eb-87bf-299276632bed.png" alt="image" /></td></tr></table>

<table><tr><td><img width=600px src="https://user-images.githubusercontent.com/52205/113934111-5bd47800-97c3-11eb-9110-e21c5a5e1991.png" alt="image" /></td></tr></table>
