### PR TITLE
Fix commit window closes immediately

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -155,7 +155,7 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
 function findCodePath(): string {
   // Check if we are currently running a Code Insiders or Codium build
   let isInsiders = vscode.env.appName.includes('Insider');
-  let isCodium = vscode.env.appName.includes('Codium');
+  let isCodium = vscode.env.appRoot.includes('codium');
   let isDarwin = process.platform === 'darwin';
   let isWindows = process.platform === 'win32';
   let isRemote = !!vscode.env.remoteName;


### PR DESCRIPTION
Fixes: https://github.com/kahole/edamagit/issues/108

The problem happens when the extension can not detect properly what is the binary of the VSCode if `code` or `codium`.
Previusly the the extension was looking at the name of the app, but even VSCodium can say "Visual Studio Code", so is better to look at the name of the binary path of the editor (`vscode.env.appRoot`), to check if it includes the word *codium*.