### PR TITLE
Fix reword

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -38,9 +38,10 @@ export async function magitCommit(repository: MagitRepository) {
 
 export async function commit({ repository, switches }: MenuState, commitArgs: string[] = []) {
 
-  let stageAllSwitch = switches?.find(({ key }) => key === '-a');
+  const stageAllSwitch = switches?.find(({ key }) => key === '-a');
+  const specifiedOnly = commitArgs.include('--only')
 
-  if (repository.indexChanges.length === 0 && !stageAllSwitch?.activated && stageAllSwitch) {
+  if (repository.indexChanges.length === 0 && !stageAllSwitch?.activated && stageAllSwitch && !specifiedOnly) {
     if (await MagitUtils.confirmAction('Nothing staged. Stage and commit all unstaged changes?')) {
       stageAllSwitch.activated = true;
     } else {


### PR DESCRIPTION
git commit rejects `--only` combined with `-a`, and in any case there's no need to ask this question for reword. Fixes #145.