### PR TITLE
Make commands callable outside of magit buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,27 @@
     "onCommand:magit.status",
     "onCommand:magit.dispatch",
     "onCommand:magit.commit",
+    "onCommand:magit.branching",
+    "onCommand:magit.merging",
+    "onCommand:magit.rebasing",
+    "onCommand:magit.resetting",
+    "onCommand:magit.pushing",
+    "onCommand:magit.pulling",
+    "onCommand:magit.remoting",
+    "onCommand:magit.logging",
+    "onCommand:magit.show-refs",
+    "onCommand:magit.diffing",
+    "onCommand:magit.tagging",
+    "onCommand:magit.cherry-picking",
+    "onCommand:magit.reverting",
+    "onCommand:magit.ignoring",
+    "onCommand:magit.running",
+    "onCommand:magit.worktree",
+    "onCommand:magit.help",
+    "onCommand:magit.stashing",
+    "onCommand:magit.submodules",
+    "onCommand:magit.fetching",
+    "onCommand:magit.process-log",
     "onCommand:magit.file-popup",
     "onCommand:magit.blame-file",
     "onCommand:magit.stage-file",
@@ -216,59 +237,59 @@
         },
         {
           "command": "magit.branching",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.merging",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.rebasing",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.resetting",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.remoting",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.logging",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.show-refs",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.diffing",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.tagging",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.cherry-picking",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.reverting",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.ignoring",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.running",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.worktree",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.visit-at-point",
@@ -308,27 +329,27 @@
         },
         {
           "command": "magit.pushing",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.pulling",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.stashing",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.submodules",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.fetching",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.process-log",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.file-popup",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "onCommand:magit.file-popup",
     "onCommand:magit.blame-file",
     "onCommand:magit.stage-file",
+    "onCommand:magit.stage-all",
     "onCommand:magit.unstage-file",
+    "onCommand:magit.unstage-all",
     "onCommand:magit.diff-file",
     "onCommand:magit.save-and-close-editor",
     "onCommand:magit.clear-and-abort-editor"
@@ -313,7 +315,7 @@
         },
         {
           "command": "magit.stage-all",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.unstage",
@@ -321,7 +323,7 @@
         },
         {
           "command": "magit.unstage-all",
-          "when": "editorLangId == magit"
+          "when": "activeEditor"
         },
         {
           "command": "magit.commit",

--- a/src/commands/stagingCommands.ts
+++ b/src/commands/stagingCommands.ts
@@ -74,7 +74,7 @@ async function stage(repository: MagitRepository, selection: Selection, selected
   }
 }
 
-export async function magitStageAll(repository: MagitRepository, currentView: DocumentView) {
+export async function magitStageAll(repository: MagitRepository) {
   return stageAllTracked(repository);
 }
 
@@ -126,7 +126,7 @@ async function unstage(repository: MagitRepository, selection: Selection, select
   }
 }
 
-export async function magitUnstageAll(repository: MagitRepository, currentView: DocumentView) {
+export async function magitUnstageAll(repository: MagitRepository) {
 
   if (await MagitUtils.confirmAction('Unstage all changes?')) {
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,15 +142,15 @@ export function activate(context: ExtensionContext) {
     commands.registerTextEditorCommand('magit.worktree', CommandPrimer.primeRepo(worktree)),
     commands.registerTextEditorCommand('magit.submodules', CommandPrimer.primeRepo(submodules)),
     commands.registerTextEditorCommand('magit.process-log', CommandPrimer.primeRepo(processView, false)),
+    commands.registerTextEditorCommand('magit.stage-all', CommandPrimer.primeRepo(magitStageAll)),
+    commands.registerTextEditorCommand('magit.unstage-all', CommandPrimer.primeRepo(magitUnstageAll)),
 
     commands.registerTextEditorCommand('magit.visit-at-point', CommandPrimer.primeRepoAndView(magitVisitAtPoint, false)),
     commands.registerTextEditorCommand('magit.apply-at-point', CommandPrimer.primeRepoAndView(magitApplyEntityAtPoint)),
     commands.registerTextEditorCommand('magit.discard-at-point', CommandPrimer.primeRepoAndView(magitDiscardAtPoint)),
     commands.registerTextEditorCommand('magit.reverse-at-point', CommandPrimer.primeRepoAndView(reverseAtPoint)),
     commands.registerTextEditorCommand('magit.stage', CommandPrimer.primeRepoAndView(magitStage)),
-    commands.registerTextEditorCommand('magit.stage-all', CommandPrimer.primeRepoAndView(magitStageAll)),
     commands.registerTextEditorCommand('magit.unstage', CommandPrimer.primeRepoAndView(magitUnstage)),
-    commands.registerTextEditorCommand('magit.unstage-all', CommandPrimer.primeRepoAndView(magitUnstageAll)),
 
     commands.registerTextEditorCommand('magit.file-popup', CommandPrimer.primeFileCommand(filePopup, false)),
     commands.registerTextEditorCommand('magit.blame-file', CommandPrimer.primeFileCommand(blameFile, false)),


### PR DESCRIPTION
See #152 - this doesn't address `stage`, `unstage` and `apply-at-point` yet, as those are a bit more complex than I thought.