### PR TITLE
Correctly highlight all-letter SHAs

### DIFF
--- a/syntaxes/magit.tmGrammar.json
+++ b/syntaxes/magit.tmGrammar.json
@@ -58,7 +58,7 @@
       "name": "invalid.deprecated"
     },
     "entity": {
-      "match": "(^stash@{\\d+}|((^)(?=.*[0-9])(?=.*[a-z])([a-z0-9]{7}) ))|(^#\\d+)",
+      "match": "(^stash@{\\d+}|((^)([0-9a-f]{7}) ))|(^#\\d+)",
       "name": "variable.object.property magit.entity"
     },
     "modified": {


### PR DESCRIPTION
By chance, I encountered a short SHA that did not contain any decimal digits, and I noticed that it was not highlighted correctly.
A similar thing could happen with a SHA containing _only_ decimal digits (but this would require the commit message to also only contain decimal digits, which is somewhat unlikely).

To fix this, I removed the two lookaheads, and instead changed the short SHA match to be just `[0-9a-f]{7}` and not include the entire range `a-z`.