### PR TITLE
fix: show stdout in addition to stderr on error

### DIFF
--- a/src/utils/gitProcessLogger.ts
+++ b/src/utils/gitProcessLogger.ts
@@ -20,8 +20,8 @@ export default class GitProcessLogger {
   }
 
   public static logGitError(error: any, entry: MagitProcessLogEntry) {
-    const errorMsg = error.stderr ?? error.message;
-    entry.stderr = errorMsg;
+    entry.stdout = error.stdout;
+    entry.stderr = error.stderr ?? error.message;
     entry.exitCode = error.exitCode !== undefined ? error.exitCode : 1;
   }
 }


### PR DESCRIPTION
git may print useful information to stdout on errors. For example,
https://github.com/pre-commit/pre-commit prints information on hook
failures to stdout when pushing. Show both stdout and stderr on
errors, similar to the current behavior on success.