### PR TITLE
feat: implement commit log for single file/path

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,11 +63,12 @@
     "onCommand:magit.process-log",
     "onCommand:magit.file-popup",
     "onCommand:magit.blame-file",
+    "onCommand:magit.diff-file",
+    "onCommand:magit.log-file",
     "onCommand:magit.stage-file",
     "onCommand:magit.stage-all",
     "onCommand:magit.unstage-file",
     "onCommand:magit.unstage-all",
-    "onCommand:magit.diff-file",
     "onCommand:magit.save-and-close-editor",
     "onCommand:magit.clear-and-abort-editor"
   ],
@@ -213,6 +214,10 @@
       {
         "command": "magit.diff-file",
         "title": "Magit Diff File"
+      },
+      {
+        "command": "magit.log-file",
+        "title": "Magit Log File"
       },
       {
         "command": "magit.stage-file",

--- a/src/commands/filePopupCommands.ts
+++ b/src/commands/filePopupCommands.ts
@@ -5,6 +5,7 @@ import * as Commit from './commitCommands';
 import * as Staging from './stagingCommands';
 import * as Blaming from './blamingCommands';
 import * as Diffing from './diffingCommands';
+import * as Logging from './loggingCommands';
 
 const filePopupMenu = {
   title: 'File Actions',
@@ -15,7 +16,7 @@ const filePopupMenu = {
     // { label: 'D', description: 'Diff...', action: () => { } },
     { label: 'd', description: 'Diff', action: ({ repository, data }: MenuState) => Diffing.diffFile(repository, data as Uri) },
     // { label: 'L', description: 'Log...', action: () => { } },
-    // { label: 'l', description: 'log', action: ({ repository, data }: MenuState) => logFile(repository, data as Uri)  },
+    { label: 'l', description: 'log', action: ({ repository, data }: MenuState) => Logging.logFile(repository, data as Uri)  },
     // { label: 't', description: 'trace', action: () => { } },
     // { label: 'B', description: 'Blame...', action: () => { } },
     { label: 'b', description: 'Blame', action: ({ repository, data }: MenuState) => Blaming.blameFile(repository, data as Uri) },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ import { merging } from './commands/mergingCommands';
 import { rebasing } from './commands/rebasingCommands';
 import { filePopup } from './commands/filePopupCommands';
 import { remoting } from './commands/remotingCommands';
-import { logging } from './commands/loggingCommands';
+import { logging, logFile } from './commands/loggingCommands';
 import { MagitProcessLogEntry } from './models/magitProcessLogEntry';
 import { processView } from './commands/processCommands';
 import { resetting, resetMixed, resetHard } from './commands/resettingCommands';
@@ -155,6 +155,7 @@ export function activate(context: ExtensionContext) {
     commands.registerTextEditorCommand('magit.file-popup', CommandPrimer.primeFileCommand(filePopup, false)),
     commands.registerTextEditorCommand('magit.blame-file', CommandPrimer.primeFileCommand(blameFile, false)),
     commands.registerTextEditorCommand('magit.diff-file', CommandPrimer.primeFileCommand(diffFile, false)),
+    commands.registerTextEditorCommand('magit.log-file', CommandPrimer.primeFileCommand(logFile, false)),
     commands.registerTextEditorCommand('magit.stage-file', CommandPrimer.primeFileCommand(stageFile)),
     commands.registerTextEditorCommand('magit.unstage-file', CommandPrimer.primeFileCommand(unstageFile)),
 


### PR DESCRIPTION
Implement command and fill in stub for file popup menu. Use --follow
to show history across file renames and exclude --graph.

Showing the commit log for all files within a directory tree also works
when using https://github.com/shirou/vscode-dired because it properly
sets file URIs for directories.