### PR TITLE
Navigation bindings for Spacemacs Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ remove the default edamagit bindings and the collisions with the Vim extension.
   
   ```json
     {
+       "key": "g g",
+       "command": "cursorTop",
+       "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/" 
+    },
+    { "key": "g r",
+       "command": "magit.refresh",
+       "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/" 
+    },
+    {
       "key": "tab",
       "command": "extension.vim_tab",
       "when": "editorFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"


### PR DESCRIPTION
Adds suggested vim-like bindings for "g g" and "g r" that work the same as they do in Spacemacs magit.

g g is a standard Vim binding to navigate to the top of the screen, the same as ctrl+home. I use it constantly on the magit status screen as I'm navigating hunks/diffs. These suggestions will make other Spacemacs users feel more at home.