### PR TITLE
Run setConfig commands sequentially.

### DIFF
--- a/src/commands/pushingCommands.ts
+++ b/src/commands/pushingCommands.ts
@@ -116,10 +116,8 @@ async function pushSetUpstream({ repository, ...rest }: MenuState) {
 
     if (remote && name) {
 
-      await Promise.all([
-        GitUtils.setConfigVariable(repository, `branch.${ref}.merge`, `refs/heads/${name}`),
-        GitUtils.setConfigVariable(repository, `branch.${ref}.remote`, remote)
-      ]);
+      await GitUtils.setConfigVariable(repository, `branch.${ref}.merge`, `refs/heads/${name}`);
+      await GitUtils.setConfigVariable(repository, `branch.${ref}.remote`, remote);
 
       repository.HEAD!.upstreamRemote = { name, remote };
 


### PR DESCRIPTION
fixes #182

`git config` commands cannot be run concurrently, but they are quick enough that you won't always see the error I see in #182. This is particularly true when running the extension in development/debug mode; I could not reproduce the error in that mode.