### PR TITLE
Fix `stashIndex` when commit hook fails

### DIFF
--- a/src/commands/stashingCommands.ts
+++ b/src/commands/stashingCommands.ts
@@ -81,7 +81,7 @@ async function stashIndex({ repository, switches }: MenuState) {
 
     if (message !== undefined) {
 
-      const intermediaryCommitArgs = ['commit', '--message', 'intermediary stash commit'];
+      const intermediaryCommitArgs = ['commit', '--no-verify', '--message', 'intermediary stash commit'];
       const stashWorktree = ['stash', 'push', '--message', 'intermediary stash'];
       const resetCommitArgs = ['reset', '--soft', repository.HEAD?.commit];
       const popIntermediateStashArgs = ['stash', 'pop', '--index', 'stash@{1}'];


### PR DESCRIPTION
If a commit hook fails, the commit will not made. So it's important to add `--no-verify` to ensure this does not happen.

Fixes https://github.com/kahole/edamagit/issues/201