### PR TITLE
fix(core): path to git executation (ref git.path)

### DIFF
--- a/package.json
+++ b/package.json
@@ -424,10 +424,14 @@
           "default": false,
           "description": "Enable automatic confirm for switch menu after enabling a switch (e.g. --force)"
         },
-        "magit.win-git-path": {
-          "type": "string",
+        "magit.git-path": {
+          "type": [
+            "string",
+            "null",
+            "array"
+          ],
           "default": "",
-          "description": "Specify path to windows git installation (parent folder to the 'Git' folder). Necesarry if git is installed in a custom path on windows"
+          "description": "Like `git.path`. Path and filename of the git executable, e.g. C:\\Program Files\\Git\\bin\\git.exe' (Windows). This can also be an array of string values containing multiple paths to look up."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export const processLog: MagitProcessLogEntry[] = [];
 
 export let gitApi: API;
 export let logPath: string;
-export let magitConfig: { displayBufferSameColumn?: boolean, forgeEnabled?: boolean, hiddenStatusSections: Set<string>, quickSwitchEnabled?: boolean, winGitPath?: string };
+export let magitConfig: { displayBufferSameColumn?: boolean, forgeEnabled?: boolean, hiddenStatusSections: Set<string>, quickSwitchEnabled?: boolean, gitPath?: string };
 
 function loadConfig() {
   let workspaceConfig = workspace.getConfiguration('magit');
@@ -58,7 +58,7 @@ function loadConfig() {
     forgeEnabled: workspaceConfig.get('forge-enabled'),
     hiddenStatusSections: readHiddenStatusSections(workspaceConfig.get('hide-status-sections')),
     quickSwitchEnabled: workspaceConfig.get('quick-switch-enabled'),
-    winGitPath: workspaceConfig.get('win-git-path')
+    gitPath: workspaceConfig.get('git-path')
   };
 
   let configCodePath: string | undefined = workspaceConfig.get('code-path');

--- a/src/utils/commandRunner/command.ts
+++ b/src/utils/commandRunner/command.ts
@@ -1,8 +1,10 @@
 import * as cp from 'child_process';
 import { CancellationToken, Disposable, Event, Uri } from 'vscode';
+import * as path from 'path';
 import { findGit } from './findGit';
 import * as iconv from '@vscode/iconv-lite-umd';
 import { dispose, IDisposable, toDisposable } from './disposable';
+import { magitConfig } from '../../extension';
 
 const canceledName = 'Canceled';
 class CancellationError extends Error {
@@ -171,7 +173,12 @@ async function exec(child: cp.ChildProcess, cancellationToken?: CancellationToke
 
 async function _exec(args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {
 
-  const git = await findGit([], () => true);
+  let pathHints = Array.isArray(magitConfig.gitPath) ? magitConfig.gitPath : magitConfig.gitPath ? [magitConfig.gitPath] : [];
+  if (pathHints.length !== 0) {
+    pathHints = pathHints.filter(p => path.isAbsolute(p));  
+  }
+    
+  const git = await findGit(pathHints, () => true);
   const child = spawn(git.path, args, options);
 
   // options.onSpawn?.(child);

--- a/src/utils/commandRunner/findGit.ts
+++ b/src/utils/commandRunner/findGit.ts
@@ -2,7 +2,6 @@ import * as cp from 'child_process';
 import { cpErrorHandler } from './command';
 import path = require('path');
 import * as which from 'which';
-import { magitConfig } from '../../extension';
 
 export interface IGit {
   path: string;
@@ -86,7 +85,6 @@ function findGitWin32InPath(onValidate: (path: string) => boolean): Promise<IGit
 
 function findGitWin32(onValidate: (path: string) => boolean): Promise<IGit> {
   return findSystemGitWin32(process.env['ProgramW6432'] as string, onValidate)
-  .then(undefined, () => findSystemGitWin32(magitConfig.winGitPath || '', onValidate))
     .then(undefined, () => findSystemGitWin32(process.env['ProgramFiles(x86)'] as string, onValidate))
     .then(undefined, () => findSystemGitWin32(process.env['ProgramFiles'] as string, onValidate))
     .then(undefined, () => findSystemGitWin32(path.join(process.env['LocalAppData'] as string, 'Programs'), onValidate))


### PR DESCRIPTION
https://github.com/kahole/edamagit/issues/243

Inspired by `git.path`, change the option from `win-git-path` to `git-path` which points to the git excutation directly.