### PR TITLE
Fix status view for very out-of-sync repos

### DIFF
--- a/src/commands/statusCommands.ts
+++ b/src/commands/statusCommands.ts
@@ -6,7 +6,7 @@ import GitTextUtils from '../utils/gitTextUtils';
 import MagitUtils from '../utils/magitUtils';
 import MagitStatusView from '../views/magitStatusView';
 import { Status, Commit, RefType, Repository, Change, Ref } from '../typings/git';
-import { MagitBranch, MagitUpstreamRef } from '../models/magitBranch';
+import { MagitBranch, MagitCommitList, MagitUpstreamRef } from '../models/magitBranch';
 import { gitRun, LogLevel } from '../utils/gitRawRunner';
 import * as Constants from '../common/constants';
 import { getCommit } from '../utils/commitCache';
@@ -18,6 +18,8 @@ import { Stash } from '../models/stash';
 import { MagitRepository } from '../models/magitRepository';
 import ViewUtils from '../utils/viewUtils';
 import { scheduleForgeStatusAsync, forgeStatusCached } from '../forge';
+
+const maxCommitsAheadBehind = 50;
 
 export async function magitRefresh() { }
 
@@ -70,18 +72,18 @@ export async function internalMagitStatus(repository: Repository): Promise<Magit
 
   const logTask = repository.state.HEAD?.commit ? repository.log({ maxEntries: 100 }) : Promise.resolve([]);
 
-  if (repository.state.HEAD?.commit) {
-    getCommit(repository, repository.state.HEAD?.commit);
-  }
+  let ahead, behind: Promise<MagitCommitList> | undefined;
 
-  let commitsAheadUpstream: string[] = [], commitsBehindUpstream: string[] = [];
-  if (repository.state.HEAD?.ahead || repository.state.HEAD?.behind) {
-    const ref = repository.state.HEAD.name;
-    const args = ['rev-list', '--left-right', `${ref}...${ref}@{u}`];
-    const res = (await gitRun(repository, args, {}, LogLevel.None)).stdout;
-    [commitsAheadUpstream, commitsBehindUpstream] = GitTextUtils.parseRevListLeftRight(res);
-    commitsAheadUpstream.map(c => getCommit(repository, c));
-    commitsBehindUpstream.map(c => getCommit(repository, c));
+  const ref = repository.state.HEAD?.name;
+  const upstream = `${ref}@{u}`;
+  // We actually must have a named ref if there is "ahead"/"behind"; you can't
+  // have an "upstream" without being on a named branch. So the && ref is just
+  // to satisfy the type checker.
+  if (repository.state.HEAD?.ahead && ref) {
+    ahead = getCommitRange(repository, upstream, ref, maxCommitsAheadBehind);
+  }
+  if (repository.state.HEAD?.behind && ref) {
+    behind = getCommitRange(repository, ref, upstream, maxCommitsAheadBehind);
   }
 
   const workingTreeChanges_NoUntracked = repository.state.workingTreeChanges
@@ -150,8 +152,12 @@ export async function internalMagitStatus(repository: Repository): Promise<Magit
 
         HEAD.upstreamRemote = HEAD.upstream;
         HEAD.upstreamRemote.commit = await upstreamRemoteCommitDetails;
-        HEAD.upstreamRemote.commitsAhead = await Promise.all(commitsAheadUpstream.map(hash => getCommit(repository, hash)));
-        HEAD.upstreamRemote.commitsBehind = await Promise.all(commitsBehindUpstream.map(hash => getCommit(repository, hash)));
+        if (ahead) {
+          HEAD.upstreamRemote.ahead = await ahead;
+        }
+        if (behind) {
+          HEAD.upstreamRemote.behind = await behind;
+        }
         HEAD.upstreamRemote.rebase = (await isRebaseUpstream) === 'true';
       }
     } catch { }
@@ -201,6 +207,22 @@ function toMagitChange(repository: Repository, change: Change, diff?: string): M
   return magitChange;
 }
 
+async function getCommitRange(repository: Repository, from: string, to: string, maxResults: number): Promise<MagitCommitList> {
+  const args = ['log', '--format=format:%H',  `${from}...${to}`, '-n', `${Math.trunc(maxResults) + 1}`];
+  let result;
+  try {
+    result = await gitRun(repository, args, {}, LogLevel.Error);
+  } catch (error) {
+    return {commits: [], truncated: false};
+  }
+  // Slice removes empty string after final newline.
+  const hashes = result.stdout.trim().split(Constants.LineSplitterRegex);
+  return {
+    commits: await Promise.all(hashes.slice(0, maxResults).map(hash => getCommit(repository, hash))),
+    truncated: hashes.length > maxResults,
+  };
+}
+
 async function pushRemoteStatus(repository: Repository): Promise<MagitUpstreamRef | undefined> {
   try {
     const HEAD = repository.state.HEAD;
@@ -208,17 +230,20 @@ async function pushRemoteStatus(repository: Repository): Promise<MagitUpstreamRe
 
     if (HEAD?.name && pushRemote) {
 
-      const args = ['rev-list', '--left-right', `${HEAD.name}...${pushRemote}/${HEAD.name}`];
-      const res = (await gitRun(repository, args, {}, LogLevel.None)).stdout;
-      const [commitsAheadPushRemote, commitsBehindPushRemote] = GitTextUtils.parseRevListLeftRight(res);
-      const commitsAhead = await Promise.all(commitsAheadPushRemote.map(c => getCommit(repository, c)));
-      const commitsBehind = await Promise.all(commitsBehindPushRemote.map(c => getCommit(repository, c)));
+      const ahead = getCommitRange(repository, `${pushRemote}/${HEAD.name}`, HEAD.name, maxCommitsAheadBehind);
+      const behind = getCommitRange(repository, HEAD.name, `${pushRemote}/${HEAD.name}`, maxCommitsAheadBehind);
 
       const refs = await getRefs(repository);
       const pushRemoteCommit = refs.find(ref => ref.remote === pushRemote && ref.name === `${pushRemote}/${HEAD.name}`)?.commit;
       const pushRemoteCommitDetails = pushRemoteCommit ? getCommit(repository, pushRemoteCommit) : Promise.resolve(undefined);
 
-      return { remote: pushRemote, name: HEAD.name, commit: await pushRemoteCommitDetails, commitsAhead, commitsBehind };
+      return { 
+        remote: pushRemote, 
+        name: HEAD.name, 
+        commit: await pushRemoteCommitDetails, 
+        ahead: await ahead,
+        behind: await behind,
+      };
     }
   } catch { }
 }

--- a/src/models/magitBranch.ts
+++ b/src/models/magitBranch.ts
@@ -7,9 +7,13 @@ export interface MagitBranch extends Branch {
   tag?: Ref;
 }
 
+export interface MagitCommitList {
+  commits: Commit[];
+  truncated: boolean;
+}
 export interface MagitUpstreamRef extends UpstreamRef {
   commit?: Commit;
-  commitsAhead?: Commit[];
-  commitsBehind?: Commit[];
+  ahead?: MagitCommitList;
+  behind?: MagitCommitList;
   rebase?: boolean;
 }

--- a/src/views/commits/unsourcedCommitsSectionView.ts
+++ b/src/views/commits/unsourcedCommitsSectionView.ts
@@ -3,17 +3,20 @@ import { Section, SectionHeaderView } from '../general/sectionHeader';
 import { Commit, UpstreamRef, Ref } from '../../typings/git';
 import { LineBreakView } from '../general/lineBreakView';
 import { CommitItemView } from './commitSectionView';
+import { MagitCommitList } from '../../models/magitBranch';
 
 export class UnsourcedCommitSectionView extends View {
   isFoldable = true;
 
+  static maxEntries = 256;
+
   get id() { return this.section.toString(); }
 
-  constructor(private section: Section, upstream: UpstreamRef, commits: Commit[], refs: Ref[]) {
+  constructor(private section: Section, upstream: UpstreamRef, list: MagitCommitList, refs: Ref[]) {
     super();
     this.subViews = [
-      new SectionHeaderView(section, commits.length, `${upstream.remote}/${upstream.name}`),
-      ...commits.map(commit => new CommitItemView(commit, undefined, refs)),
+      new SectionHeaderView(section, list.commits.length, `${upstream.remote}/${upstream.name}`, list.truncated),
+      ...list.commits.map(commit => new CommitItemView(commit, undefined, refs)),
       new LineBreakView()
     ];
   }

--- a/src/views/general/sectionHeader.ts
+++ b/src/views/general/sectionHeader.ts
@@ -22,7 +22,7 @@ export enum Section {
 
 export class SectionHeaderView extends UnclickableTextView {
 
-  constructor(section: Section, count?: number, extraText?: string) {
-    super(`${section.valueOf()}${extraText ? ' ' + extraText + '' : ''}${count ? ' (' + count + ')' : ''}`);
+  constructor(section: Section, count?: number, extraText?: string, truncated=false) {
+    super(`${section.valueOf()}${extraText ? ' ' + extraText : ''}${count ? ` (${count}${truncated ? '+': ''})` : ''}`);
   }
 }

--- a/src/views/magitStatusView.ts
+++ b/src/views/magitStatusView.ts
@@ -77,19 +77,19 @@ export default class MagitStatusView extends DocumentView {
 
     const refs = magitState.remotes.reduce((prev, remote) => remote.branches.concat(prev), magitState.branches.concat(magitState.tags));
 
-    if (magitState.HEAD?.upstreamRemote?.commitsAhead?.length && !magitConfig.hiddenStatusSections.has('unmerged')) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnmergedInto, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsAhead, refs));
-    } else if (magitState.HEAD?.pushRemote?.commitsAhead?.length && !magitConfig.hiddenStatusSections.has('unpushed')) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnpushedTo, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsAhead, refs));
+    if (magitState.HEAD?.upstreamRemote?.ahead?.commits.length && !magitConfig.hiddenStatusSections.has('unmerged')) {
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnmergedInto, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.ahead, refs));
+    } else if (magitState.HEAD?.pushRemote?.ahead?.commits.length && !magitConfig.hiddenStatusSections.has('unpushed')) {
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnpushedTo, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.ahead, refs));
     }
-    if (magitState.log.length > 0 && !magitState.HEAD?.upstreamRemote?.commitsAhead?.length && !magitConfig.hiddenStatusSections.has('recent commits')) {
+    if (magitState.log.length > 0 && !magitState.HEAD?.upstreamRemote?.ahead?.commits.length && !magitConfig.hiddenStatusSections.has('recent commits')) {
       this.addSubview(new CommitSectionView(Section.RecentCommits, magitState.log.slice(0, 10), refs));
     }
 
-    if (magitState.HEAD?.upstreamRemote?.commitsBehind?.length && !magitConfig.hiddenStatusSections.has('unpulled')) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.commitsBehind, refs));
-    } else if (magitState.HEAD?.pushRemote?.commitsBehind?.length) {
-      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.commitsBehind, refs));
+    if (magitState.HEAD?.upstreamRemote?.behind?.commits.length && !magitConfig.hiddenStatusSections.has('unpulled')) {
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.upstreamRemote, magitState.HEAD.upstreamRemote.behind, refs));
+    } else if (magitState.HEAD?.pushRemote?.behind?.commits.length) {
+      this.addSubview(new UnsourcedCommitSectionView(Section.UnpulledFrom, magitState.HEAD.pushRemote, magitState.HEAD.pushRemote.behind, refs));
     }
 
     if (magitState.forgeState?.pullRequests?.length && !magitConfig.hiddenStatusSections.has('pull requests')) {


### PR DESCRIPTION
Fix for https://github.com/kahole/edamagit/issues/255. See commit messages for some further details. 

However:

- It's a little annoying that this means we have to introduce the new
   `MagitCommitSummary` type. I would have liked to just create an object
   that satisfies the full Commit interface, but that interface has a `parents` field, which we can't easily collect without a more extensive operation :confused: .

 - It seems like the log-parsing logic in getCommitsAheadBehind should
   live in gitTextUtils.ts, but it's tightly coupled with the exact `git
   log` command.

 - I'm new to TypeScript, please don't hesitate to let me know if I've
   done anything stupid!
   
One alternative strategy that I haven't tried: Maybe instead of this `MagitCommitSummary` thing, we could just still use `getCommit`, but do it only for the commits we are actually going to display in the UI. Probably 256 `getCommit` calls is pretty OK, especially since it will be cached for later. 
   
The downside of that is that then we need a way to communicate from the model code to the view code that the commit list has been truncated, this seems kinda ugly in its own right. Maybe to fix that we could just pass through the `Branch` to the view code and then have _it_ do `getCommit` according to its own knowledge of how many commits will actually get rendered? But then I guess we'd be mixing up model and view code in an awkward way.

So yeah I dunno, let me know what you think.   