### PR TITLE
fix vscode-insiders path for the remote environment

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -206,7 +206,7 @@ function findCodePath(): string {
   if (isDarwin) {
     codePath = execPath.split(/(?<=\.app)/)[0] + '/Contents/Resources/app/bin/' + codePath;
   } else {
-    codePath = path.join(path.dirname(execPath), 'bin', codePath);
+    codePath = path.join(path.dirname(execPath), 'bin', (isRemote ? 'remote-cli' : ''), codePath);
   }
 
   if (!fs.existsSync(codePath)) {


### PR DESCRIPTION
I'm using vscode insiders from macOS to develop on remote Linux machine. When I try to commit edamagit fails because it cannot find code cli.

 `code-insiders` it is in PATH when running terminal from vscode:
```sh
which code-insiders
/home/ianic/.vscode-server-insiders/bin/9800cf6dd6bf4634889d60720ef46a400f3a7298/bin/remote-cli/code-insiders
```

The problem is that edamagit is looking into `../bin/code-insiders` instead of `../bin/remote-cli/code-insiders`. So it fails to find it and [fallback](https://github.com/kahole/edamagit/blob/e9462afbdad4ed0a84ec3b1d92c6a9eb4dd20aa2/src/commands/commitCommands.ts#L212) to using `code` from PATH. Which works if insiders version is not used. In insiders version there is no `code` cli in PATH but `code-insiders`.

I think that [this](https://github.com/kahole/edamagit/issues/194) issue has the same root cause.