### PR TITLE
Show file contents from commit or stash

### DIFF
--- a/src/commands/visitAtPointCommands.ts
+++ b/src/commands/visitAtPointCommands.ts
@@ -1,4 +1,4 @@
-import { window, workspace, TextEditorRevealType, Range, Position, Selection, commands } from 'vscode';
+import { window, workspace, TextEditorRevealType, Range, Position, Selection, commands, WorkspaceEdit, Uri } from 'vscode';
 import { MagitRepository } from '../models/magitRepository';
 import { CommitItemView } from '../views/commits/commitSectionView';
 import { DocumentView } from '../views/general/documentView';
@@ -21,6 +21,8 @@ import { PullRequestView } from '../views/forge/pullRequestView';
 import { sep } from 'path';
 import { ErrorMessageView } from '../views/errorMessageView';
 import { processView } from './processCommands';
+import { stashToMagitChanges } from './diffingCommands';
+import { ContextualMagitChange } from '../models/magitChange';
 
 export async function magitVisitAtPoint(repository: MagitRepository, currentView: DocumentView) {
 
@@ -36,8 +38,27 @@ export async function magitVisitAtPoint(repository: MagitRepository, currentView
 
     const change = (selectedView as ChangeView).change;
 
-    if (change.hunks?.length) {
-      return visitHunk(selectedView.subViews.find(v => v instanceof HunkView) as HunkView);
+    /* Check if is ContextualMagitChange */ 
+    if ((change as ContextualMagitChange).contextId !== undefined) {
+      const contextual = change as ContextualMagitChange;
+      const content = await gitRun(repository.gitRepository, ['show', `${contextual.contextId}:${change.relativePath}`]);
+
+      let path = change.uri.path;
+      let filename = path.split('/').pop() ?? '';
+      let extension = filename.split('.', 2).pop() ?? '';
+      if (extension.length > 0) {
+        path = path.slice(0, -extension.length - 1);
+      }
+
+      workspace.openTextDocument(Uri.parse(`untitled:${path}.~${contextual.contextId}~.${extension}`))
+        .then(doc => window.showTextDocument(doc))
+        .then(editor => {
+          editor.edit((edit) => {
+            edit.insert(new Position(0, 0), content.stdout);
+          });
+        });
+    } else if (change.hunks?.length) {
+        return visitHunk(selectedView.subViews.find(v => v instanceof HunkView) as HunkView);
     } else {
 
       // Check if change path is a directory. Reveal directories in file explorer
@@ -145,5 +166,5 @@ export async function visitCommit(repository: MagitRepository, commitHash: strin
   const commit: MagitCommit = { hash: commitHash, message: '', parents: [] };
 
   const uri = CommitDetailView.encodeLocation(repository, commit.hash);
-  return ViewUtils.showView(uri, new CommitDetailView(uri, commit, result.stdout));
+  return ViewUtils.showView(uri, new CommitDetailView(uri, commit, header.stdout, stashToMagitChanges(repository, commitHash, nameStatus.stdout, diffs.stdout)));
 }

--- a/src/models/magitChange.ts
+++ b/src/models/magitChange.ts
@@ -6,3 +6,7 @@ export interface MagitChange extends Change {
   diff?: string;
   relativePath?: string;
 }
+
+export interface ContextualMagitChange extends MagitChange {
+  contextId: string
+}


### PR DESCRIPTION
This requires #268, otherwise, there would be an error in arguments to `stashToMagitChanges`.

Emacs magit allows browsing contents of files from older configs or changes that were stashed. I tried to implement something similar here.

The way it works is that it opens an unsaved file, with `~{commit hash}~` before the extension (that is to let vscode recognize language correctly). If the user saves the file, it will be saved right away, without any warnings or anything like that. I think it would be great if that could be changed because it's probably not the intended use case to save the file. The thing is that I am not sure how to achieve that in an effective way.

I am open to ideas on improving this.