### PR TITLE
Concise log decorate

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,6 +454,16 @@
         "description": "Name of a git ref from a remote."
       },
       {
+        "id": "magit-head-name",
+        "superType": "label",
+        "description": "Name of the (local) HEAD git ref."
+      },
+      {
+        "id": "magit-remote-head-name",
+        "superType": "label",
+        "description": "Name of a HEAD git ref on a remote repo."
+      },
+      {
         "id": "magit-tag-name",
         "superType": "label",
         "description": "Name of a git tag."
@@ -467,6 +477,12 @@
           ],
           "magit-remote-ref-name": [
             "variable.other.constant"
+          ],
+          "magit-head-name": [
+            "entity.name.tag"
+          ],
+          "magit-remote-head-name": [
+            "variable.object.property"
           ],
           "magit-tag-name": [
             "string.highlight"

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -14,5 +14,7 @@ export const MagitDocumentSelector: DocumentSelector = { scheme: MagitUriScheme,
 export enum SemanticTokenTypes {
   RefName = 'magit-ref-name',
   RemoteRefName = 'magit-remote-ref-name',
+  HeadName = 'magit-head-name',
+  RemoteHeadName = 'magit-remote-head-name',
   TagName = 'magit-tag-name',
 }


### PR DESCRIPTION
This PR makes the refs displayed in the log view more concise, similar to how they currently work in the status view and how they work in Magit:

"Magit displays references in logs a bit differently from how Git does it.

Local branches are blue and remote branches are green. Of course that depends on the used theme, as do the colors used for other types of references. The current branch has a box around it, as do remote branches that are their respective remote’s HEAD branch.

If a local branch and its push-target point at the same commit, then their names are combined to preserve space and to make that relationship visible."

It adds two new semantic token types, one for local HEAD and one for remote HEADs. When generating the ref portion of a commit line with viewUtils.generateRefTokensLine(), it checks if a ref is HEAD or a remote HEAD and applies the correct token type.

logView now uses generateRefTokensLine() for the ref portion of a commit line, instead of parsing the refs directly from the log output.

<img width="755" alt="Screenshot 2023-09-10 at 12 47 28 PM" src="https://github.com/kahole/edamagit/assets/31324068/2276ee38-c2a2-4108-989a-64303f61c2ba">
