### PR TITLE
Show running git command in git status message

### DIFF
--- a/src/utils/gitRawRunner.ts
+++ b/src/utils/gitRawRunner.ts
@@ -1,6 +1,8 @@
 import { Repository } from '../typings/git';
 import { run, SpawnOptions } from './commandRunner/command';
+import { window } from 'vscode';
 import GitProcessLogger from './gitProcessLogger';
+import * as Constants from '../common/constants';
 
 export enum LogLevel {
   None,
@@ -8,7 +10,10 @@ export enum LogLevel {
   Detailed
 }
 
-export async function gitRun(repository: Repository, args: string[], spawnOptions?: SpawnOptions, logLevel = LogLevel.Detailed) {
+export async function gitRun(repository: Repository, args: string[], spawnOptions?: SpawnOptions, logLevel = LogLevel.Detailed, showStatus: boolean = true) {
+  if (showStatus) {
+    window.setStatusBarMessage(`Running git ${args.join(' ')}...`);
+  }
 
   let logEntry;
   if (logLevel > LogLevel.None) {
@@ -26,10 +31,17 @@ export async function gitRun(repository: Repository, args: string[], spawnOption
       GitProcessLogger.logGitResult(result, logEntry);
     }
 
+    if (showStatus) {
+      window.setStatusBarMessage(`Git finished successfully`, Constants.StatusMessageDisplayTimeout);
+    }
     return result;
-  } catch (error) {
+  } catch (error: any) {
     if (logLevel > LogLevel.None && logEntry) {
       GitProcessLogger.logGitError(error, logEntry);
+    }
+
+    if (showStatus) {
+      window.setStatusBarMessage(error.message);
     }
     throw error;
   }


### PR DESCRIPTION
Shows running git command in the status bar, resolves #270.

I have tried to implement showing the running git command, it works. The problem is that it looks to me the raw runner shouldn't do anything in the vscode. So this is violating single responsibility principle. I am not really sure what the best way of solving that could be. Maybe creating one semi-level, that would just show the status bar, and call the raw gitRun. Then replacing every gitRun with this higher gitRun that has access to the UI?