### PR TITLE
Add command toggle-all-folds-for-change-views

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,14 @@
       {
         "command": "magit.toggle-fold",
         "title": "Magit Toggle Fold"
+      },
+      {
+        "command": "magit.toggle-all-folds-in-change-section-at-point",
+        "title": "Magit Toggle All Folds in Change Section at Point"
+      },
+      {
+        "command": "magit.toggle-all-folds-for-change-views",
+        "title": "Magit Toggle All Folds for Change Views"
       }
     ],
     "menus": {
@@ -366,6 +374,14 @@
         },
         {
           "command": "magit.toggle-fold",
+          "when": "editorLangId == magit"
+        },
+        {
+          "command": "magit.toggle-all-folds-in-change-section-at-point",
+          "when": "editorLangId == magit"
+        },
+        {
+          "command": "magit.toggle-all-folds-for-change-views",
           "when": "editorLangId == magit"
         }
       ]

--- a/src/commands/macros.ts
+++ b/src/commands/macros.ts
@@ -1,6 +1,7 @@
 import { commands, TextEditor, Range, window, Selection, TextEditorRevealType, Position } from 'vscode';
 import { MagitRepository } from '../models/magitRepository';
 import { ChangeSectionView } from '../views/changes/changesSectionView';
+import { ChangeView } from '../views/changes/changeView';
 import { DocumentView } from '../views/general/documentView';
 import { View } from '../views/general/view';
 
@@ -34,6 +35,17 @@ export async function toggleAllFoldsInChangeSection(repo: MagitRepository, view:
     for (let i = 1; i < changeSectionView.subViews.length - 1; i++) {
       changeSectionView.subViews[i].folded = newFoldState;
     }
+  }
+}
+
+export async function toggleAllFoldsForChangeViews(repo: MagitRepository, view: DocumentView) {
+  let changeViews = Array.from(view.walkAllSubViews()).filter(x => x instanceof ChangeView);
+  if (changeViews.length === 0) {
+    return;
+  }
+  const newFoldState = !changeViews[0].folded;
+  for (let changeView of changeViews) {
+    changeView.folded = newFoldState;
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { magitVisitAtPoint } from './commands/visitAtPointCommands';
 import { MagitRepository } from './models/magitRepository';
 import { magitCommit, setCodePath } from './commands/commitCommands';
 import { magitStage, magitStageAll, magitUnstageAll, magitUnstage, stageFile, unstageFile } from './commands/stagingCommands';
-import { saveClose, clearSaveClose, quitMagitView, toggleAllFoldsInChangeSection, moveToPreviousEntity, moveToNextEntity } from './commands/macros';
+import { saveClose, clearSaveClose, quitMagitView, toggleAllFoldsForChangeViews, toggleAllFoldsInChangeSection, moveToPreviousEntity, moveToNextEntity } from './commands/macros';
 import HighlightProvider from './providers/highlightProvider';
 import SemanticTokensProvider from './providers/semanticTokensProvider';
 import { CommandPrimer } from './commands/commandPrimer';
@@ -179,6 +179,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerTextEditorCommand('magit.move-next-entity', CommandPrimer.primeRepoAndView(moveToNextEntity, false)));
   context.subscriptions.push(commands.registerTextEditorCommand('magit.move-previous-entity', CommandPrimer.primeRepoAndView(moveToPreviousEntity, false)));
   context.subscriptions.push(commands.registerTextEditorCommand('magit.toggle-all-folds-in-change-section-at-point', CommandPrimer.primeRepoAndView(toggleAllFoldsInChangeSection, true)));
+  context.subscriptions.push(commands.registerTextEditorCommand('magit.toggle-all-folds-for-change-views', CommandPrimer.primeRepoAndView(toggleAllFoldsForChangeViews, true)));
 
   context.subscriptions.push(commands.registerTextEditorCommand('magit.save-and-close-editor', saveClose));
   context.subscriptions.push(commands.registerTextEditorCommand('magit.clear-and-abort-editor', clearSaveClose));

--- a/src/views/general/view.ts
+++ b/src/views/general/view.ts
@@ -85,4 +85,11 @@ export abstract class View {
   addSubview(...views: View[]) {
     this.subViews.push(...views);
   }
+
+  *walkAllSubViews(): Generator<View> {
+    for (let subView of this.subViews) {
+      yield subView;
+      yield* subView.walkAllSubViews();
+    }
+  }
 }


### PR DESCRIPTION
- Add a command `toggle-all-folds-for-change-views` for toggling all folds on ChangeViews
- Also, because it's adjacent, add a couple missing package.json declarations for the `toggle-all-folds-in-change-section-at-point` command added in this PR a couple years ago:
  - https://github.com/kahole/edamagit/issues/155