### PR TITLE
fix: issue 233

### DIFF
--- a/src/commands/statusCommands.ts
+++ b/src/commands/statusCommands.ts
@@ -44,7 +44,7 @@ export async function magitStatus(): Promise<any> {
       if (editor?.document.uri.path === MagitStatusView.UriPath) {
         return;
       }
-      return workspace.openTextDocument(view.uri).then(doc => window.showTextDocument(doc, { viewColumn: ViewUtils.showDocumentColumn(), preview: false }));
+      return workspace.openTextDocument(view.uri).then(doc => window.showTextDocument(doc, { viewColumn: ViewUtils.showDocumentColumn(doc), preview: false }));
     }
 
     repository = await internalMagitStatus(repository.gitRepository);

--- a/src/utils/viewUtils.ts
+++ b/src/utils/viewUtils.ts
@@ -1,12 +1,16 @@
 import { MagitRepository } from '../models/magitRepository';
 import { View } from '../views/general/view';
-import { Selection, Position, Uri, workspace, window, TextDocumentShowOptions, ViewColumn } from 'vscode';
+import { Selection, Position, Uri, workspace, window, TextDocumentShowOptions, ViewColumn, TextDocument } from 'vscode';
 import { Ref, RefType } from '../typings/git';
 import { Token } from '../views/general/semanticTextView';
 import { SemanticTokenTypes } from '../common/constants';
 import GitTextUtils from './gitTextUtils';
 import { DocumentView } from '../views/general/documentView';
 import { magitConfig, views } from '../extension';
+
+function hasUri(obj: unknown): obj is { uri: Uri } {
+  return typeof obj === 'object' && obj !== null && 'uri' in obj && obj.uri instanceof Uri;
+}
 
 export default class ViewUtils {
 
@@ -26,7 +30,16 @@ export default class ViewUtils {
     return window.showTextDocument(doc, { viewColumn: ViewUtils.showDocumentColumn(), ...textDocumentShowOptions });
   }
 
-  public static showDocumentColumn(): ViewColumn {
+  public static showDocumentColumn(doc?: TextDocument): ViewColumn {
+    if (doc) {
+      for (const tabGroup of window.tabGroups.all) {
+        for (const tab of tabGroup.tabs) {
+          if (hasUri(tab.input) && tab.input.uri.toString() === doc.uri.toString()) {
+            return tabGroup.viewColumn;
+          }
+        }
+      }
+    }
     const activeColumn = window.activeTextEditor?.viewColumn;
 
     if (magitConfig.displayBufferSameColumn) {


### PR DESCRIPTION
Check all editors when computing `viewColumn`, so that one magit status buffer won't be open in different editors

close #233 