### PR TITLE
Update extensions.vim_tab entry in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ remove the default edamagit bindings and the collisions with the Vim extension.
     },
     {
       "key": "tab",
-      "command": "-extension.vim_tab",
-      "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+      "command": "-extension.vim_tab"
     },
     {
       "key": "x",


### PR DESCRIPTION
The keybindings for `extensions.vim_tab` did not work for me. The tab key didn't toggle folding of sections as expected. Removing the `when` field in the `-extensions.vim_tab` entry seemed to fix the problem for me.

Full disclosure: I don't have much knowledge of VS Code or its extensions and configuration. I just poked at a few things trying to fix my problem, and this seemed to work. As a result, I thought I'd raise this PR in case I stumbled across a desirable change.