### PR TITLE
Set --no-ext-diff when running git diff

### DIFF
--- a/src/commands/diffingCommands.ts
+++ b/src/commands/diffingCommands.ts
@@ -82,7 +82,7 @@ async function diffWorktree({ repository }: MenuState) {
 }
 
 async function diff(repository: MagitRepository, id: string, args: string[] = []) {
-  const diffResult = await gitRun(repository.gitRepository, ['diff', ...args]);
+  const diffResult = await gitRun(repository.gitRepository, ['diff', '--no-ext-diff', ...args]);
 
   const uri = DiffView.encodeLocation(repository, id);
   return ViewUtils.showView(uri, new DiffView(uri, diffResult.stdout));


### PR DESCRIPTION
If a user has the following set in their git config:

```properties
[diff]
  external = difft
```

edmagit will fail to parse the `git diff` output. This should fix that.

Fixes https://github.com/kahole/edamagit/issues/228