### PR TITLE
Improve `magit-branch-spinoff` implementation

### DIFF
--- a/src/commands/branchingCommands.ts
+++ b/src/commands/branchingCommands.ts
@@ -207,12 +207,48 @@ async function createNewSpinoff({ repository }: MenuState) {
     prompt: 'Name for new branch',
   });
 
-  if (newBranchName && newBranchName.length > 0) {
-    const args = ['checkout', '-B', newBranchName];
-    return gitRun(repository.gitRepository, args);
+  if (!newBranchName || newBranchName.length < 1) {
+    return window.setStatusBarMessage(
+      'No name given for new branch',
+      Constants.StatusMessageDisplayTimeout
+    );
+  }
+
+  if (repository.branches.find(b => b.name === newBranchName)) {
+    return window.setStatusBarMessage(
+      `Cannot spin off ${newBranchName}. It already exists`,
+      Constants.StatusMessageDisplayTimeout
+    );
+  }
+
+  const base = repository.HEAD?.name;
+
+  if (!base) {
+    return window.setStatusBarMessage(
+      'No branch checked out',
+      Constants.StatusMessageDisplayTimeout
+    );
+  }
+
+  // Save current commit hash of base branch for later reference
+  const baseCommit = repository.HEAD?.commit;
+
+  // Get upsteam branch commit hash of base branch
+  const upstreamBranchCommit = repository.HEAD.upstreamRemote?.commit?.hash;
+
+  // Checkout new branch
+  await gitRun(repository.gitRepository, ['checkout', '-b', newBranchName]);
+
+  if (upstreamBranchCommit && baseCommit !== upstreamBranchCommit) {
+    await gitRun(repository.gitRepository, ['branch', '-f', base, upstreamBranchCommit]);
+
+    window.setStatusBarMessage(
+      `Branch ${base} was reset to upstream`,
+      Constants.StatusMessageDisplayTimeout
+    );
   } else {
     window.setStatusBarMessage(
-      'No name given for new branch',
+      `Branch ${base} not changed`,
       Constants.StatusMessageDisplayTimeout
     );
   }


### PR DESCRIPTION
This PR addresses the comment from @glasser in https://github.com/kahole/edamagit/issues/290#issuecomment-2018550944. The edamagit `magit-branch-spinoff` command should now behave more like the original one in magit.

@glasser, would you mind taking a look at the code for this PR and checking if this is what you'd expect?