### PR TITLE
Set items schema for hide-status-sections configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -434,7 +434,12 @@
         "magit.hide-status-sections": {
           "type": "array",
           "default": [],
-          "description": "Array of section names to be hidden in status view. The section names that may be hidden are: 'issues', 'pull requests', 'recent commits', 'staged', 'stashes', 'unmerged', 'unpulled', 'unpushed', 'unstaged', 'untracked'."
+          "description": "Section names to be hidden in status view.",
+          "items": {
+            "type": "string",
+            "enum": ["issues", "pull requests", "recent commits", "staged", "stashes", "unmerged", "unpulled", "unpushed", "unstaged", "untracked"],
+            "uniqueItems": true
+          }
         },
         "magit.quick-switch-enabled": {
           "type": "boolean",


### PR DESCRIPTION
Provide Intellisense and UI in settings for magit.hide-status-sections configuration option.

Before:

|<img width="539" alt="Screenshot 2024-04-10 at 10 57 26 AM" src="https://github.com/kahole/edamagit/assets/191085/34ec039c-9294-4046-ad8a-90e41d97d5d6">|<img width="288" alt="Screenshot 2024-04-10 at 10 56 59 AM" src="https://github.com/kahole/edamagit/assets/191085/2358adc2-64bf-4f1c-a271-409e69dda04a">|
|-|-|

After:

|<img width="539" alt="Screenshot 2024-04-10 at 11 02 04 AM 1" src="https://github.com/kahole/edamagit/assets/191085/f482882d-56db-4e8b-8531-06336645c4a8">|<img width="274" alt="Screenshot 2024-04-10 at 11 02 57 AM" src="https://github.com/kahole/edamagit/assets/191085/a1216591-0f0d-4f16-8c3e-6a9ff543b129">|
|-|-|

https://github.com/kahole/edamagit/assets/191085/003956b9-c8a3-4c86-a6cd-5aee227d0a7f