### PR TITLE
Support q to exit blame (fix #263)

### DIFF
--- a/package.json
+++ b/package.json
@@ -748,6 +748,11 @@
         "command": "magit.bisect",
         "key": "shift+b",
         "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
+      },
+      {
+        "command": "workbench.action.closeActiveEditor",
+        "key": "q",
+        "when": "editorTextFocus && resourceScheme == 'magit' && resourcePath =~ /^Blame\\.magit@/"
       }
     ]
   },


### PR DESCRIPTION
- Fixes #263

Implements @kahole's suggestion of 

> There may be some way to have a shortcut that checks for the blame view and can allow us to use «q» for those views.