### PR TITLE
Fix: Don't pass `ELECTRON_RUN_AS_NODE` to subprocess

### DIFF
--- a/src/utils/commandRunner/command.ts
+++ b/src/utils/commandRunner/command.ts
@@ -261,6 +261,10 @@ function spawn(path: string, args: string[], options: SpawnOptions = {}): cp.Chi
     LC_ALL: 'en_US.UTF-8',
     LANG: 'en_US.UTF-8',
     GIT_PAGER: 'cat',
+    // Don't include the ELECTRON_RUN_AS_NODE environment variable - if we're running in a remote host,
+    // this will be picked up from the client and will cause failures.
+    ELECTRON_RUN_AS_NODE: undefined
+
 
     // TODO: add ask pass functionality
     // GIT_ASKPASS: path.join(__dirname, 'askpass.sh'),


### PR DESCRIPTION
This change addresses #303, which prevents commit messages from being written in remote hosts.

In VSCode's `server-cli.js`, it checks for the `ELECTRON_RUN_AS_NODE` environment variable, and if it's present it maps the `fs` module to point to the `original-fs` module:

```javascript
(process.env.ELECTRON_RUN_AS_NODE || process.versions.electron) &&
  c.define("fs", ["original-fs"], function (r) {
    return r;
  }),
```

This module is present in Electron, but not in base NodeJS; base NodeJS is what's used by the VSCode remote server, so having this environment variable present when `code` is called from a subprocess will cause failure.

An alternative, but more involved, fix here might be to move to using `ShellExecution` or `ProcessExecution` rather than `child_process`; I expect that they will support calling `code` from a nested process, but they have a fairly different API.