### PR TITLE
add force-if-includes option to push command

### DIFF
--- a/src/commands/pushingCommands.ts
+++ b/src/commands/pushingCommands.ts
@@ -38,6 +38,7 @@ export async function pushing(repository: MagitRepository) {
   const switches = [
     { key: '-f', name: '--force-with-lease', description: 'Force with lease' },
     { key: '-F', name: '--force', description: 'Force' },
+    { key: '-i', name: '--force-if-includes', description: 'Force if includes' },
     { key: '-h', name: '--no-verify', description: 'Disable hooks' },
     { key: '-d', name: '--dry-run', description: 'Dry run' }
   ];


### PR DESCRIPTION
This is a useful option to have along side `--force-with-lease`. I would've preferred to add a setting to automatically append it when using `--force-with-lease`, but I couldn't find a clean way to do so.