### PR TITLE
Support Windsurf editor

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -185,6 +185,7 @@ function findCodePath(): string {
   // Check if we are currently running a Code Insiders or Codium build
   let isInsiders = vscode.env.appName.includes('Insider');
   let isCodium = vscode.env.appRoot.includes('codium');
+  let isWindsurf = vscode.env.appName.includes('Windsurf');
   let isDarwin = process.platform === 'darwin';
   let isWindows = process.platform === 'win32';
   let isRemote = !!vscode.env.remoteName;
@@ -200,6 +201,10 @@ function findCodePath(): string {
   if (isWindows && isRemote) {
     // On window remote server, 'code' alias doesn't exist
     codePath += '.cmd';
+  }
+  if (isWindsurf && isDarwin) {
+    // Windsurf on Mac: is called 'windsurf'
+    codePath = 'windsurf';
   }
 
   // Find the code binary on different platforms.


### PR DESCRIPTION
The code binary is called `windsurf`. Without this patch Windsurf opens VS Code to edit the commit message since it resorts to the `code` binary found in system path.