### PR TITLE
Focus loss after commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <h1 align="center">
   <br>
   <a href="https://marketplace.visualstudio.com/items?itemName=kahole.magit">
@@ -111,16 +112,16 @@ remove the default edamagit bindings and the collisions with the Vim extension.
 
 <details>
   <summary>Bindings - keybindings.json</summary>
-  
+
   ```json
     {
        "key": "g g",
        "command": "cursorTop",
-       "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/" 
+       "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
     },
     { "key": "g r",
        "command": "magit.refresh",
-       "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/" 
+       "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
     },
     {
       "key": "tab",

--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -194,7 +194,9 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
           const stagedEditorViewColumn = ViewUtils.showDocumentColumn();
           await vscode.window.showTextDocument(stagedEditor.document, { viewColumn: stagedEditorViewColumn, preview: false });
           await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-          vscode.commands.executeCommand(`workbench.action.navigate${stagedEditorViewColumn === vscode.ViewColumn.One ? 'Right' : 'Left'}`);
+          if (! magitConfig.displayBufferSameColumn) {
+            vscode.commands.executeCommand(`workbench.action.navigate${stagedEditorViewColumn === vscode.ViewColumn.One ? 'Right' : 'Left'}`);
+          }
         }
       }
     }

--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -215,7 +215,7 @@ function findCodePath(): string {
   if (isCodium && !isDarwin) {
     codePath = 'codium';
   }
-  
+
   if (isInsiders && !isDarwin) {
     // On Mac the binary for the Insiders build is still called `code`
     codePath += '-insiders';
@@ -223,7 +223,7 @@ function findCodePath(): string {
 
   if (isCursor && isRemote) {
     // Cursor remote-server does not symlink to code but to cursor.
-    codePath = 'cursor'; 
+    codePath = 'cursor';
   }
 
   if (isWindows && isRemote) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ const config = {
           {
             options: {
               eslintPath: require.resolve('eslint'),
-    
+
             },
             loader: require.resolve('eslint-loader'),
           },


### PR DESCRIPTION
After finishing a commit, the focus jumps to another editor group:

![before2](https://github.com/user-attachments/assets/e52b90c5-3be7-453d-a7e4-bc75757a8f6c)
![before1](https://github.com/user-attachments/assets/1888b108-8bc2-4eaa-8a1b-cc59a1be4f20)

This is supremely annoying, especially when rebasing, so I put a condition around it, to only do that when 'display-buffer-function' is set to 'other-column'. I think that kind of makes sense conceptually, but let me know if you think it would be better served by introducing a separate config option.

[after.apng](https://i.imgur.com/AkShXii.png)

Thanks!


EDIT: the after would not render properly, and github doesn't support apng, so had to upload it somewhere else.