### PR TITLE
Avoid closing workspace when using workspace file

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -127,12 +127,18 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
     // `--reuse-window` forces VSCode to open COMMIT_EDITMSG in the current
     // workspace even if the file is more closely related to a different
     // window/workspace.
-    // 
+    //
     // https://github.com/kahole/edamagit/issues/301
-    let currentInstancePath = '';
-    if (vscode.workspace.workspaceFolders?.at(0)) {
-      currentInstancePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
-    }
+    //
+    // It's important that the workspace file is preferred over the folder
+    // (given that it's in use) as the workspace will otherwise be closed
+    // and reopened.
+    //
+    // https://github.com/kahole/edamagit/issues/316
+    const currentInstancePath =
+      vscode.workspace.workspaceFile?.fsPath ??
+      vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath ??
+      '';
 
     const cmd = `"${codePath}" --wait --reuse-window ${currentInstancePath} `;
 


### PR DESCRIPTION
Prefer referencing the workspace file if available. Otherwise the current window will reopen the workspace, but not using the file.

I tested this locally by running `vsce package` and manually installing the produced `vsix` file. However, I have no experience developing VS Code extensions, and very little experience with TypeScript, so please let me now if there's anything I can improve :pray: 

Fixes #316