### PR TITLE
use windsurf executable

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -221,6 +221,11 @@ function findCodePath(): string {
     codePath += '-insiders';
   }
 
+  if (isWindsurf) {
+    // Windsurf : executable is called 'windsurf'
+    codePath = 'windsurf';
+  }
+
   if (isCursor && isRemote) {
     // Cursor remote-server does not symlink to code but to cursor.
     codePath = 'cursor'; 
@@ -229,10 +234,6 @@ function findCodePath(): string {
   if (isWindows && isRemote) {
     // On window remote server, 'code' alias doesn't exist
     codePath += '.cmd';
-  }
-  if (isWindsurf && isDarwin) {
-    // Windsurf on Mac: is called 'windsurf'
-    codePath = 'windsurf';
   }
 
   // Find the code binary on different platforms.


### PR DESCRIPTION
The current code only uses windsurf on Darwin. As far as I can tell, the executable for windsurf is *always* called windsurf, so generalize it to work everywhere. This may be too broad, I myself am using Windows with WSL; edamagit currently runs code which (for some reason...) opens `cursor`... very annoying.

PS. Love edamagit, can't live without it!