### PR TITLE
 Fix Windsurf detection on Linux without breaking Windows behavior

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -209,6 +209,7 @@ function findCodePath(): string {
   let isWindsurf = vscode.env.appName.includes('Windsurf');
   let isDarwin = process.platform === 'darwin';
   let isWindows = process.platform === 'win32';
+  let isLinux = process.platform === 'linux';
   let isRemote = !!vscode.env.remoteName;
 
   let codePath = 'code';
@@ -230,7 +231,7 @@ function findCodePath(): string {
     // On window remote server, 'code' alias doesn't exist
     codePath += '.cmd';
   }
-  if (isWindsurf && isDarwin) {
+  if (isWindsurf &&  (isDarwin || isLinux)) {
     // Windsurf on Mac: is called 'windsurf'
     codePath = 'windsurf';
   }


### PR DESCRIPTION
## Problem

Currently in `findCodePath()`, Edamagit only switches `codePath` to `'windsurf'` if both `isWindsurf` **and** `isDarwin` (macOS) are true.
This means Linux users running Winsurf incorrectly fall back to the generic `'code'` binary, causing Git editor operations to fail.

At the same time, we don't want to break Windows users, where calling `code.cmd` may still work inside Winsurf setups.

## Changes

- Added `isLinux = process.platform === 'linux'` for clarity and consistency.
- Changed Windsurf detection to:

```ts
if (isWindsurf && (isDarwin || isLinux)) {
  codePath = 'windsurf';
}
```

This ensures:
- **Mac** + Windsurf → uses `windsurf`
- **Linux** + Windsurf → uses `windsurf`
- **Windows** + Windsurf → keeps existing `code(.cmd)` behavior (safe fallback)

No changes to detection for Codium, Code Insiders, Cursor, or normal VSCode.

## Why this fix

- Minimal, surgical change.
- Matches existing code style.
- Avoids unintentional breakage for Windows users.
- Solves real problem for Linux users with Winsurf.
