### PR TITLE
Fix version number in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.65]
+## [0.6.66]
 - bugfix: get rid of false git error message when running "status"
 
 ## [0.6.65]


### PR DESCRIPTION
v0.6.65 was duplicated and v0.6.66 is the latest release, so I assume this was a copy-paste mistake.