### PR TITLE
Update README for NES (Next Edit Suggestions) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ remove the default edamagit bindings and the collisions with the Vim extension.
     {
       "key": "tab",
       "command": "extension.vim_tab",
-      "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"
+      "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && !inlineEditIsVisible && editorLangId != 'magit'"
     },
     {
       "key": "tab",


### PR DESCRIPTION
Allows pressing tab in normal mode to accept a pending edit suggestion.

Based on: https://github.com/VSCodeVim/Vim/commit/bba5de0b3a18f07dccf815a00b40233da3673f95
See: https://code.visualstudio.com/blogs/2025/02/12/next-edit-suggestions