### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
See https://github.com/actions/setup-node/issues/1275#issuecomment-2788204086

There are updates for `actions/checkout` (v2 -> v4) `HaaLeo/publish-vscode-extension` (v1 -> v2) as well, but only doing the bare minimum to get the CI green again here.

Perhaps a minimal [dependabot config](https://github.com/qutebrowser/qutebrowser/blob/main/.github/dependabot.yml) to update actions might make sense?