### PR TITLE
Allow push elsewhere to push to different branches

### DIFF
--- a/src/commands/pushingCommands.ts
+++ b/src/commands/pushingCommands.ts
@@ -127,13 +127,22 @@ async function pushSetUpstream({ repository, ...rest }: MenuState) {
   }
 }
 
-async function pushElsewhere() {
-  return commands.executeCommand('git.pushTo');
+async function pushElsewhere({ repository, switches }: MenuState) {
+  const ref = repository.HEAD?.name;
+  const remote = await MagitUtils.chooseRef(repository, `Push ${ref} to`, false, false, true, true);
+
+  if (remote && ref) {
+    const [remoteName, ...remoteBranchNameParts] = remote.split('/');
+    const remoteBranchName = remoteBranchNameParts.join('/');
+
+    const args = ['push', ...MenuUtil.switchesToArgs(switches), remoteName, `${ref}:${remoteBranchName}`];
+    return gitRun(repository.gitRepository, args);
+  }
 }
 
 async function pushOther({ repository, switches }: MenuState) {
 
-  const ref = await MagitUtils.chooseRef(repository, 'Push', false, false, true);
+  const ref = await MagitUtils.chooseRef(repository, 'Push', true, false, true);
   const remote = await MagitUtils.chooseRef(repository, `Push ${ref} to`, false, false, true, true);
 
   const [remoteName, ...remoteBranchNameParts] = remote.split('/');


### PR DESCRIPTION
This allows the "push elsewhere" command to push to remote branches different than the current one.,
 
![May-29-2025 11-51-44](https://github.com/user-attachments/assets/195aad9e-e257-496d-ac04-986e1efb59a0)

This is really helpful when staging environments use branch-based deploys and I want to force push to a staging environment.