### PR TITLE
Decorate word-level diff and more highlighting improvements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
+        "diff": "^8.0.0",
         "eslint": "^7.16.0",
         "eslint-loader": "^4.0.2",
         "glob": "^7.1.6",
@@ -1203,10 +1204,11 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2614,6 +2616,16 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
@@ -4901,9 +4913,9 @@
       "dev": true
     },
     "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
       "dev": true
     },
     "dir-glob": {
@@ -5965,6 +5977,12 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -765,6 +765,7 @@
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
+    "diff": "^8.0.0",
     "eslint": "^7.16.0",
     "eslint-loader": "^4.0.2",
     "glob": "^7.1.6",

--- a/src/providers/contentProvider.ts
+++ b/src/providers/contentProvider.ts
@@ -12,6 +12,8 @@ export default class ContentProvider implements vscode.TextDocumentContentProvid
 
   private _subscriptions: vscode.Disposable;
 
+  private _decoratedEditors: Set<vscode.TextEditor> = new Set();
+
   constructor() {
 
     this.onDidChange = this.viewUpdatedEmitter.event;
@@ -42,11 +44,22 @@ export default class ContentProvider implements vscode.TextDocumentContentProvid
         if (editor && event.document === editor.document) {
           DecorationUtils.decorateWordLevelDiff(editor);
         }
+      }),
+      vscode.window.onDidChangeVisibleTextEditors(editors => {
+        for (const editor of editors) {
+          if (editor && editor.document.uri.scheme === Constants.MagitUriScheme) {
+            if (!this._decoratedEditors.has(editor)) {
+              this._decoratedEditors.add(editor);
+              DecorationUtils.decorateWordLevelDiff(editor);
+            }
+          }
+        }
       }));
   }
 
   dispose() {
     this._subscriptions.dispose();
+    this._decoratedEditors.clear();
     this.viewUpdatedEmitter.dispose();
   }
 

--- a/src/providers/contentProvider.ts
+++ b/src/providers/contentProvider.ts
@@ -3,6 +3,7 @@ import { views } from '../extension';
 import * as Constants from '../common/constants';
 import FilePathUtils from '../utils/filePathUtils';
 import MagitUtils from '../utils/magitUtils';
+import DecorationUtils from '../utils/decorateUtils';
 
 export default class ContentProvider implements vscode.TextDocumentContentProvider {
 
@@ -35,7 +36,13 @@ export default class ContentProvider implements vscode.TextDocumentContentProvid
               }
             }
           }
-        }));
+        }),
+      vscode.workspace.onDidChangeTextDocument(event => {
+        const editor = vscode.window.activeTextEditor;
+        if (editor && event.document === editor.document) {
+          DecorationUtils.decorateWordLevelDiff(editor);
+        }
+      }));
   }
 
   dispose() {

--- a/src/utils/decorateUtils.ts
+++ b/src/utils/decorateUtils.ts
@@ -6,11 +6,21 @@ const hunkHeaderDecoration = vscode.window.createTextEditorDecorationType({
   isWholeLine: true,
 });
 
-const addedDecoration = vscode.window.createTextEditorDecorationType({
+const insertedLineDecor = vscode.window.createTextEditorDecorationType({
+  backgroundColor: '#304135',
+  isWholeLine: true,
+});
+
+const deletedLineDecor = vscode.window.createTextEditorDecorationType({
+  backgroundColor: '#3f3239',
+  isWholeLine: true,
+});
+
+const insertedWordDecor = vscode.window.createTextEditorDecorationType({
   backgroundColor: '#4a714f',
 });
 
-const removedDecoration = vscode.window.createTextEditorDecorationType({
+const deletedWordDecor = vscode.window.createTextEditorDecorationType({
   backgroundColor: '#714545',
 });
 
@@ -22,16 +32,20 @@ export default class DecorationUtils {
 
     // First, clear all existing decorations
     editor.setDecorations(hunkHeaderDecoration, []);
-    editor.setDecorations(addedDecoration, []);
-    editor.setDecorations(removedDecoration, []);
+    editor.setDecorations(insertedLineDecor, []);
+    editor.setDecorations(deletedLineDecor, []);
+    editor.setDecorations(insertedWordDecor, []);
+    editor.setDecorations(deletedWordDecor, []);
 
     // Now, start to find the added and removed ranges
     const text = editor.document.getText();
     const lines = text.split('\n');
 
     const hunkHeaderRanges: vscode.Range[] = [];
-    const addedTextRanges: vscode.Range[] = [];
-    const removedTextRanges: vscode.Range[] = [];
+    const insertedLineRanges: vscode.Range[] = [];
+    const deletedLineRanges: vscode.Range[] = [];
+    const insertedWordRanges: vscode.Range[] = [];
+    const deletedWordRanges: vscode.Range[] = [];
 
     let i = 0;
     while (i < lines.length) {
@@ -40,28 +54,31 @@ export default class DecorationUtils {
         hunkHeaderRanges.push(new vscode.Range(i, 0, i, 0));
         i++;
       } else if (lines[i].startsWith('-')) {
-        // Decorate hunk
-        const removedBlock: { text: string; line: number }[] = [];
-        const addedBlock: { text: string; line: number }[] = [];
+        // Decorate deleted and inserted words and lines
 
-        // collect removed lines
+        const deletedBlock: { text: string; line: number }[] = [];
+        const insertedBlock: { text: string; line: number }[] = [];
+
+        // collect deleted lines
         while (i < lines.length && lines[i].startsWith('-')) {
-          removedBlock.push({ text: lines[i].slice(1), line: i });
+          deletedLineRanges.push(new vscode.Range(i, 0, i, 0));
+          deletedBlock.push({ text: lines[i].slice(1), line: i });
           i++;
         }
 
-        // collect added lines
+        // collect inserted lines
         while (i < lines.length && lines[i].startsWith('+')) {
-          addedBlock.push({ text: lines[i].slice(1), line: i });
+          insertedLineRanges.push(new vscode.Range(i, 0, i, 0));
+          insertedBlock.push({ text: lines[i].slice(1), line: i });
           i++;
         }
 
-        const pairCount = Math.min(removedBlock.length, addedBlock.length);
+        const pairCount = Math.min(deletedBlock.length, insertedBlock.length);
 
         // word-level diff for matched pairs
         for (let j = 0; j < pairCount; j++) {
-          const oldLine = removedBlock[j];
-          const newLine = addedBlock[j];
+          const oldLine = deletedBlock[j];
+          const newLine = insertedBlock[j];
 
           const changes = diffWordsWithSpace(oldLine.text, newLine.text);
 
@@ -75,7 +92,7 @@ export default class DecorationUtils {
                 oldOffset
               );
               if (start !== -1) {
-                removedTextRanges.push(
+                deletedWordRanges.push(
                   new vscode.Range(
                     oldLine.line,
                     start,
@@ -91,7 +108,7 @@ export default class DecorationUtils {
                 newOffset
               );
               if (start !== -1) {
-                addedTextRanges.push(
+                insertedWordRanges.push(
                   new vscode.Range(
                     newLine.line,
                     start,
@@ -107,6 +124,12 @@ export default class DecorationUtils {
             }
           }
         }
+      } else if (lines[i].startsWith('+')) {
+        // collect inserted lines
+        while (i < lines.length && lines[i].startsWith('+')) {
+          insertedLineRanges.push(new vscode.Range(i, 0, i, 0));
+          i++;
+        }
       } else {
         // No decoration
         i++;
@@ -115,7 +138,9 @@ export default class DecorationUtils {
 
     // Highlight the changes
     editor.setDecorations(hunkHeaderDecoration, hunkHeaderRanges);
-    editor.setDecorations(addedDecoration, addedTextRanges);
-    editor.setDecorations(removedDecoration, removedTextRanges);
+    editor.setDecorations(insertedLineDecor, insertedLineRanges);
+    editor.setDecorations(deletedLineDecor, deletedLineRanges);
+    editor.setDecorations(insertedWordDecor, insertedWordRanges);
+    editor.setDecorations(deletedWordDecor, deletedWordRanges);
   }
 }

--- a/src/utils/decorateUtils.ts
+++ b/src/utils/decorateUtils.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { diffWordsWithSpace } from 'diff';
+import * as Constants from '../common/constants';
 
 const hunkHeaderDecoration = vscode.window.createTextEditorDecorationType({
   backgroundColor: '#1f3e4e',
@@ -26,7 +27,7 @@ const deletedWordDecor = vscode.window.createTextEditorDecorationType({
 
 export default class DecorationUtils {
   public static decorateWordLevelDiff(editor: vscode.TextEditor) {
-    if (!editor) {
+    if (!editor || editor.document.uri.scheme !== Constants.MagitUriScheme) {
       return;
     }
 

--- a/src/utils/decorateUtils.ts
+++ b/src/utils/decorateUtils.ts
@@ -7,11 +7,11 @@ const hunkHeaderDecoration = vscode.window.createTextEditorDecorationType({
 });
 
 const addedDecoration = vscode.window.createTextEditorDecorationType({
-  backgroundColor: '#21702f',
+  backgroundColor: '#4a714f',
 });
 
 const removedDecoration = vscode.window.createTextEditorDecorationType({
-  backgroundColor: '#911619',
+  backgroundColor: '#714545',
 });
 
 export default class DecorationUtils {

--- a/src/utils/decorateUtils.ts
+++ b/src/utils/decorateUtils.ts
@@ -1,14 +1,18 @@
 import * as vscode from 'vscode';
 import { diffWordsWithSpace } from 'diff';
 
+const hunkHeaderDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: '#1f3e4e',
+  isWholeLine: true,
+});
+
 const addedDecoration = vscode.window.createTextEditorDecorationType({
-  backgroundColor: 'rgba(0,255,0,0.3)',
+  backgroundColor: '#21702f',
 });
 
 const removedDecoration = vscode.window.createTextEditorDecorationType({
-  backgroundColor: 'rgba(255,0,0,0.5)',
+  backgroundColor: '#911619',
 });
-
 
 export default class DecorationUtils {
   public static decorateWordLevelDiff(editor: vscode.TextEditor) {
@@ -16,7 +20,8 @@ export default class DecorationUtils {
       return;
     }
 
-    // First, clear all existing highlighting of refined changes
+    // First, clear all existing decorations
+    editor.setDecorations(hunkHeaderDecoration, []);
     editor.setDecorations(addedDecoration, []);
     editor.setDecorations(removedDecoration, []);
 
@@ -24,90 +29,93 @@ export default class DecorationUtils {
     const text = editor.document.getText();
     const lines = text.split('\n');
 
-    const addedRanges: vscode.Range[] = [];
-    const removedRanges: vscode.Range[] = [];
+    const hunkHeaderRanges: vscode.Range[] = [];
+    const addedTextRanges: vscode.Range[] = [];
+    const removedTextRanges: vscode.Range[] = [];
 
     let i = 0;
     while (i < lines.length) {
-      if (!lines[i].startsWith('-')) {
-        // Not in a diff hunk, skip
+      if (lines[i].startsWith('@@')) {
+        // Decorate diff headers
+        hunkHeaderRanges.push(new vscode.Range(i, 0, i, 0));
         i++;
-        continue;
-      }
+      } else if (lines[i].startsWith('-')) {
+        // Decorate hunk
+        const removedBlock: { text: string; line: number }[] = [];
+        const addedBlock: { text: string; line: number }[] = [];
 
-      // Inside a diff hunk, prepare to collect changes
-      const removedBlock: { text: string; line: number }[] = [];
-      const addedBlock: { text: string; line: number }[] = [];
+        // collect removed lines
+        while (i < lines.length && lines[i].startsWith('-')) {
+          removedBlock.push({ text: lines[i].slice(1), line: i });
+          i++;
+        }
 
-      // collect removed lines
-      while (i < lines.length && lines[i].startsWith('-')) {
-        removedBlock.push({ text: lines[i].slice(1), line: i });
-        i++;
-      }
+        // collect added lines
+        while (i < lines.length && lines[i].startsWith('+')) {
+          addedBlock.push({ text: lines[i].slice(1), line: i });
+          i++;
+        }
 
-      // collect added lines
-      while (i < lines.length && lines[i].startsWith('+')) {
-        addedBlock.push({ text: lines[i].slice(1), line: i });
-        i++;
-      }
+        const pairCount = Math.min(removedBlock.length, addedBlock.length);
 
-      const pairCount = Math.min(removedBlock.length, addedBlock.length);
+        // word-level diff for matched pairs
+        for (let j = 0; j < pairCount; j++) {
+          const oldLine = removedBlock[j];
+          const newLine = addedBlock[j];
 
-      // word-level diff for matched pairs
-      for (let j = 0; j < pairCount; j++) {
-        const oldLine = removedBlock[j];
-        const newLine = addedBlock[j];
+          const changes = diffWordsWithSpace(oldLine.text, newLine.text);
 
-        const changes = diffWordsWithSpace(oldLine.text, newLine.text);
+          let oldOffset = 1;
+          let newOffset = 1;
 
-        let oldOffset = 1;
-        let newOffset = 1;
-
-        for (const change of changes) {
-          if (change.removed) {
-            const start = lines[oldLine.line].indexOf(
-              change.value,
-              oldOffset
-            );
-            if (start !== -1) {
-              removedRanges.push(
-                new vscode.Range(
-                  new vscode.Position(oldLine.line, start),
-                  new vscode.Position(
+          for (const change of changes) {
+            if (change.removed) {
+              const start = lines[oldLine.line].indexOf(
+                change.value,
+                oldOffset
+              );
+              if (start !== -1) {
+                removedTextRanges.push(
+                  new vscode.Range(
+                    oldLine.line,
+                    start,
                     oldLine.line,
                     start + change.value.length
                   )
-                )
+                );
+              }
+              oldOffset += change.value.length;
+            } else if (change.added) {
+              const start = lines[newLine.line].indexOf(
+                change.value,
+                newOffset
               );
-            }
-            oldOffset += change.value.length;
-          } else if (change.added) {
-            const start = lines[newLine.line].indexOf(
-              change.value,
-              newOffset
-            );
-            if (start !== -1) {
-              addedRanges.push(
-                new vscode.Range(
-                  new vscode.Position(newLine.line, start),
-                  new vscode.Position(
+              if (start !== -1) {
+                addedTextRanges.push(
+                  new vscode.Range(
+                    newLine.line,
+                    start,
                     newLine.line,
                     start + change.value.length
                   )
-                )
-              );
+                );
+              }
+              newOffset += change.value.length;
+            } else {
+              oldOffset += change.value.length;
+              newOffset += change.value.length;
             }
-            newOffset += change.value.length;
-          } else {
-            oldOffset += change.value.length;
-            newOffset += change.value.length;
           }
         }
+      } else {
+        // No decoration
+        i++;
       }
     }
 
     // Highlight the changes
-    editor.setDecorations(addedDecoration, addedRanges);
-    editor.setDecorations(removedDecoration, removedRanges);
+    editor.setDecorations(hunkHeaderDecoration, hunkHeaderRanges);
+    editor.setDecorations(addedDecoration, addedTextRanges);
+    editor.setDecorations(removedDecoration, removedTextRanges);
   }
 }

--- a/src/utils/decorateUtils.ts
+++ b/src/utils/decorateUtils.ts
@@ -1,0 +1,113 @@
+import * as vscode from 'vscode';
+import { diffWordsWithSpace } from 'diff';
+
+const addedDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: 'rgba(0,255,0,0.3)',
+});
+
+const removedDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: 'rgba(255,0,0,0.5)',
+});
+
+
+export default class DecorationUtils {
+  public static decorateWordLevelDiff(editor: vscode.TextEditor) {
+    if (!editor) {
+      return;
+    }
+
+    // First, clear all existing highlighting of refined changes
+    editor.setDecorations(addedDecoration, []);
+    editor.setDecorations(removedDecoration, []);
+
+    // Now, start to find the added and removed ranges
+    const text = editor.document.getText();
+    const lines = text.split('\n');
+
+    const addedRanges: vscode.Range[] = [];
+    const removedRanges: vscode.Range[] = [];
+
+    let i = 0;
+    while (i < lines.length) {
+      if (!lines[i].startsWith('-')) {
+        // Not in a diff hunk, skip
+        i++;
+        continue;
+      }
+
+      // Inside a diff hunk, prepare to collect changes
+      const removedBlock: { text: string; line: number }[] = [];
+      const addedBlock: { text: string; line: number }[] = [];
+
+      // collect removed lines
+      while (i < lines.length && lines[i].startsWith('-')) {
+        removedBlock.push({ text: lines[i].slice(1), line: i });
+        i++;
+      }
+
+      // collect added lines
+      while (i < lines.length && lines[i].startsWith('+')) {
+        addedBlock.push({ text: lines[i].slice(1), line: i });
+        i++;
+      }
+
+      const pairCount = Math.min(removedBlock.length, addedBlock.length);
+
+      // word-level diff for matched pairs
+      for (let j = 0; j < pairCount; j++) {
+        const oldLine = removedBlock[j];
+        const newLine = addedBlock[j];
+
+        const changes = diffWordsWithSpace(oldLine.text, newLine.text);
+
+        let oldOffset = 1;
+        let newOffset = 1;
+
+        for (const change of changes) {
+          if (change.removed) {
+            const start = lines[oldLine.line].indexOf(
+              change.value,
+              oldOffset
+            );
+            if (start !== -1) {
+              removedRanges.push(
+                new vscode.Range(
+                  new vscode.Position(oldLine.line, start),
+                  new vscode.Position(
+                    oldLine.line,
+                    start + change.value.length
+                  )
+                )
+              );
+            }
+            oldOffset += change.value.length;
+          } else if (change.added) {
+            const start = lines[newLine.line].indexOf(
+              change.value,
+              newOffset
+            );
+            if (start !== -1) {
+              addedRanges.push(
+                new vscode.Range(
+                  new vscode.Position(newLine.line, start),
+                  new vscode.Position(
+                    newLine.line,
+                    start + change.value.length
+                  )
+                )
+              );
+            }
+            newOffset += change.value.length;
+          } else {
+            oldOffset += change.value.length;
+            newOffset += change.value.length;
+          }
+        }
+      }
+    }
+
+    // Highlight the changes
+    editor.setDecorations(addedDecoration, addedRanges);
+    editor.setDecorations(removedDecoration, removedRanges);
+  }
+}


### PR DESCRIPTION
Hi,

Thanks for this amazing package! I come from Emacs, and luckily found your package for VSCode!

I implemented this PR to improve the word-level diff highlighting, similar to what is supported by Emacs' magit.

The new features included are:
- Highlight refined at the word-level the added/removed text
- Highlight added/removed lines
- Highlight diff hunk headers

Below is a screenshot:

<img width="890" height="901" alt="Screenshot 2025-08-29 at 5 45 02 PM" src="https://github.com/user-attachments/assets/d35d7f74-9264-4c48-9ebc-6ee793685a1f" />

Can you review and merge it?

Thank you!

