### PR TITLE
Fix committing on Windows, and folders with space in path

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -140,7 +140,7 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
       vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath ??
       '';
 
-    const cmd = `"${codePath}" --wait --reuse-window ${currentInstancePath} `;
+    const cmd = `"${codePath}" --wait --reuse-window "${currentInstancePath}" `;
 
     const env: NodeJS.ProcessEnv = { 'GIT_EDITOR': cmd };
 


### PR DESCRIPTION
As per #340, when on Windows, attempting to commit (`c c`) opens up additional tabs in VS Code, which must be closed first, before the `COMMIT_EDITMSG` tab will work. If you just ignore these extra tabs and use `COMMIT_EDITMSG`, committing fails silently (which is quite annoying as the commit message you typed is lost).

For example, if the current project is in `C:\Users\luke\devel\edamagittest` (no space), then attempting to commit produces this:

<img width="563" height="165" alt="ksnip_20250919-105347" src="https://github.com/user-attachments/assets/4d459bce-8ed6-4f95-b81a-3fa36eb73c23" />

If the path has a space in it, like `C:\Users\luke\devel\edamagit test`, then you get further additional tabs, like this:

<img width="781" height="231" alt="ksnip_20250919-105008" src="https://github.com/user-attachments/assets/5f0fe684-6c89-4cca-999b-359cc882ebf7" />

I have seen the bug on multiple Windows machines (at least 3). This bug also affects other platforms if the project folder has a space in it, as noted in the bug report.

This PR fixes it. I have verified that the fix works both for Windows and for Linux.

Fixes #340

Thanks so much for your time, and all your work on edamagit which is awesome. It would be super helpful to the junior members of my team (whom I've got started using edamagit) if this bug fix could be merged and a new release done, thanks!
