### PR TITLE
Add `--update-refs` switch to rebasing commands

### DIFF
--- a/src/commands/rebasingCommands.ts
+++ b/src/commands/rebasingCommands.ts
@@ -29,6 +29,7 @@ export async function rebasing(repository: MagitRepository) {
       { key: '-A', name: '--autostash', description: 'Autostash' },
       { key: '-i', name: '--interactive', description: 'Interactive' },
       { key: '-h', name: '--no-verify', description: 'Disable hooks' },
+      { key: '-u', name: '--update-refs', description: 'Update any branches that point to commits being rebased' },
     ];
 
     const HEAD = repository.HEAD;


### PR DESCRIPTION
This should resolve #354.

One item from the issue was not implemented:

>Possibly default to enabled if rebase.updateRefs is set in git config

I don't believe this is necessary, and I did a quick check to confirm. Enabling the `rebase.updateRefs` setting globally using `git config --global rebase.updateRefs true` is already respected by edamagit, since it executes regular git rebase commands that respect this setting.