### PR TITLE
Fix stray `<timestamp>` tab when committing from untitled workspace

### DIFF
--- a/src/commands/commitCommands.ts
+++ b/src/commands/commitCommands.ts
@@ -135,12 +135,21 @@ export async function runCommitLikeCommand(repository: MagitRepository, args: st
     // and reopened.
     //
     // https://github.com/kahole/edamagit/issues/316
-    const currentInstancePath =
-      vscode.workspace.workspaceFile?.fsPath ??
-      vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath ??
-      '';
+    // If the workspace is unsaved (`workspaceFile` is set to `untitled:<timestamp>`)
+    // we can't pass a sensible value to --reuse-workspace, it only takes saved workspaces,
+    // so in that case don't pass a value at all and let vscode pick the window.
+    //
+    // https://github.com/kahole/edamagit/issues/346.
+    const workspaceFile = vscode.workspace.workspaceFile;
+    let currentInstancePath: string | undefined;
+    if (workspaceFile?.scheme === 'file') {
+      currentInstancePath = workspaceFile.fsPath;
+    } else if (workspaceFile === undefined) {
+      currentInstancePath = vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath;
+    }
 
-    const cmd = `"${codePath}" --wait --reuse-window "${currentInstancePath}" `;
+    const pathArg = currentInstancePath ? `"${currentInstancePath}" ` : '';
+    const cmd = `"${codePath}" --wait --reuse-window ${pathArg}`;
 
     const env: NodeJS.ProcessEnv = { 'GIT_EDITOR': cmd };
 


### PR DESCRIPTION
I kept hitting into the issue reported in #346 and I think this MR fixes it.

When the open workspace is an unsaved multi-root workspace, `workspace.workspaceFile` is a URI with `untitled:` scheme whose `fsPath` is a bare `Date.now()` string (e.g. `1774006721975`). Interpolating that into `GIT_EDITOR` caused `code --reuse-window` to receive it as a relative file path and open a stray empty tab alongside `COMMIT_EDITMSG` on every commit.

With the changes in the PR it we only pass `workspaceFile.fsPath` when its scheme is `file`. For untitled workspaces, omit the path argument entirely passing a folder path instead would regress #316 by prompting to save the untitled workspace.